### PR TITLE
Feature/refine matchers requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.3.3)
+    mongory (1.3.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mongory/matchers.rb
+++ b/lib/mongory/matchers.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'matchers/abstract_matcher'
+require_relative 'matchers/abstract_multi_matcher'
+require_relative 'matchers/abstract_operator_matcher'
+require_relative 'matchers/main_matcher'
 require_relative 'matchers/and_matcher'
 require_relative 'matchers/collection_matcher'
 require_relative 'matchers/elem_match_matcher'
@@ -12,7 +16,6 @@ require_relative 'matchers/in_matcher'
 require_relative 'matchers/dig_value_matcher'
 require_relative 'matchers/lt_matcher'
 require_relative 'matchers/lte_matcher'
-require_relative 'matchers/main_matcher'
 require_relative 'matchers/ne_matcher'
 require_relative 'matchers/nin_matcher'
 require_relative 'matchers/not_matcher'

--- a/lib/mongory/matchers.rb
+++ b/lib/mongory/matchers.rb
@@ -3,7 +3,7 @@
 require_relative 'matchers/abstract_matcher'
 require_relative 'matchers/abstract_multi_matcher'
 require_relative 'matchers/abstract_operator_matcher'
-require_relative 'matchers/main_matcher'
+require_relative 'matchers/default_matcher'
 require_relative 'matchers/and_matcher'
 require_relative 'matchers/collection_matcher'
 require_relative 'matchers/elem_match_matcher'

--- a/lib/mongory/matchers/README.md
+++ b/lib/mongory/matchers/README.md
@@ -39,7 +39,7 @@ graph TD
     T[LteMatcher]
   end
 
-  A --> B[MainMatcher]
+  A --> B[DefaultMatcher]
   A --> U[InMatcher]
   A --> V[NinMatcher]
   A --> C --> MultipleConditions

--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'mongory/utils'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/abstract_multi_matcher.rb
+++ b/lib/mongory/matchers/abstract_multi_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/abstract_operator_matcher.rb
+++ b/lib/mongory/matchers/abstract_operator_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/and_matcher.rb
+++ b/lib/mongory/matchers/and_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_multi_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/and_matcher.rb
+++ b/lib/mongory/matchers/and_matcher.rb
@@ -6,7 +6,7 @@ module Mongory
     # Temp Description
     class AndMatcher < AbstractMultiMatcher
       def build_sub_matcher(condition)
-        MainMatcher.new(condition)
+        DefaultMatcher.new(condition)
       end
 
       def operator

--- a/lib/mongory/matchers/collection_matcher.rb
+++ b/lib/mongory/matchers/collection_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_multi_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/condition_matcher.rb
+++ b/lib/mongory/matchers/condition_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_multi_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/default_matcher.rb
+++ b/lib/mongory/matchers/default_matcher.rb
@@ -4,7 +4,7 @@ module Mongory
   # Temp Description
   module Matchers
     # Temp Description
-    class MainMatcher < AbstractMatcher
+    class DefaultMatcher < AbstractMatcher
       def match?(record)
         if @condition == record
           true

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'main_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -4,7 +4,7 @@ module Mongory
   # Temp Description
   module Matchers
     # Temp Description
-    class DigValueMatcher < MainMatcher
+    class DigValueMatcher < DefaultMatcher
       # These classes are not expected to dig value but respond to :[] method
       CLASSES_NOT_ALLOW_TO_DIG = [
         ::String,

--- a/lib/mongory/matchers/elem_match_matcher.rb
+++ b/lib/mongory/matchers/elem_match_matcher.rb
@@ -4,7 +4,7 @@ module Mongory
   # Temp Description
   module Matchers
     # Temp Description
-    class ElemMatchMatcher < MainMatcher
+    class ElemMatchMatcher < DefaultMatcher
       def match?(record)
         return false unless record.is_a?(Array)
 

--- a/lib/mongory/matchers/elem_match_matcher.rb
+++ b/lib/mongory/matchers/elem_match_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'main_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/eq_matcher.rb
+++ b/lib/mongory/matchers/eq_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/exists_matcher.rb
+++ b/lib/mongory/matchers/exists_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/gt_matcher.rb
+++ b/lib/mongory/matchers/gt_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/gte_matcher.rb
+++ b/lib/mongory/matchers/gte_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/in_matcher.rb
+++ b/lib/mongory/matchers/in_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/lt_matcher.rb
+++ b/lib/mongory/matchers/lt_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/lte_matcher.rb
+++ b/lib/mongory/matchers/lte_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/main_matcher.rb
+++ b/lib/mongory/matchers/main_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/ne_matcher.rb
+++ b/lib/mongory/matchers/ne_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/nin_matcher.rb
+++ b/lib/mongory/matchers/nin_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/not_matcher.rb
+++ b/lib/mongory/matchers/not_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'main_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/not_matcher.rb
+++ b/lib/mongory/matchers/not_matcher.rb
@@ -4,7 +4,7 @@ module Mongory
   # Temp Description
   module Matchers
     # Temp Description
-    class NotMatcher < MainMatcher
+    class NotMatcher < DefaultMatcher
       def match?(record)
         !super(record)
       end

--- a/lib/mongory/matchers/or_matcher.rb
+++ b/lib/mongory/matchers/or_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_multi_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/or_matcher.rb
+++ b/lib/mongory/matchers/or_matcher.rb
@@ -6,7 +6,7 @@ module Mongory
     # Temp Description
     class OrMatcher < AbstractMultiMatcher
       def build_sub_matcher(condition)
-        MainMatcher.new(condition)
+        DefaultMatcher.new(condition)
       end
 
       def operator

--- a/lib/mongory/matchers/present_matcher.rb
+++ b/lib/mongory/matchers/present_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/matchers/regex_matcher.rb
+++ b/lib/mongory/matchers/regex_matcher.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'abstract_operator_matcher'
-
 module Mongory
   # Temp Description
   module Matchers

--- a/lib/mongory/query_matcher.rb
+++ b/lib/mongory/query_matcher.rb
@@ -12,7 +12,7 @@ module Mongory
     end
 
     def match?(record)
-      main_matcher.match?(normalize_record(record))
+      default_matcher.match?(normalize_record(record))
     end
 
     def normalize_record(record)
@@ -22,8 +22,8 @@ module Mongory
       deep_convert(record)
     end
 
-    define_instance_cache_method(:main_matcher) do
-      Mongory::Matchers::MainMatcher.new(@condition)
+    define_instance_cache_method(:default_matcher) do
+      Mongory::Matchers::DefaultMatcher.new(@condition)
     end
 
     define_instance_cache_method(:data_converter) do

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end


### PR DESCRIPTION
1. Removed all individual `require_relative` statements from matcher files.
- Centralized matcher loading in `lib/mongory/matchers.rb` for better maintainability.
- This makes matcher dependency management clearer, avoids circular requires, and simplifies future extension or dynamic loading.
2. Renamed `MainMatcher` to `DefaultMatcher` to better reflect its role as the fallback matcher for top-level conditions and reusable base logic.
- Updated all references across related matchers (e.g. DigValueMatcher, ElemMatchMatcher) to use `DefaultMatcher` as the new base.
- This change improves naming consistency and aligns better with its function as a general-purpose conditional dispatcher.