### PR TITLE
Feature/issue 6 separate convert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.3.4)
+    mongory (1.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require 'time'
+require 'date'
 require_relative 'mongory/version'
 require_relative 'mongory/config'
 require_relative 'mongory/utils'
+require_relative 'mongory/data_converter'
 require_relative 'mongory/matchers'
 require_relative 'mongory/query_matcher'
 require_relative 'mongory/query_builder'
@@ -12,7 +15,7 @@ require_relative 'mongory/core_ext'
 # Temp Description
 module Mongory
   def self.build_query(records)
-    Mongory::QueryBuilder.new(records)
+    QueryBuilder.new(records)
   end
 
   def self.configure
@@ -20,7 +23,11 @@ module Mongory
   end
 
   def self.config
-    @config ||= Config.new
+    Config
+  end
+
+  def self.data_converter
+    DataConverter
   end
 
   class Error < StandardError; end

--- a/lib/mongory/config.rb
+++ b/lib/mongory/config.rb
@@ -2,11 +2,5 @@
 
 module Mongory
   # Temp Description
-  class Config
-    attr_accessor :data_converter
-
-    def initialize
-      @data_converter = :as_json
-    end
-  end
+  Config = Object.new
 end

--- a/lib/mongory/data_converter.rb
+++ b/lib/mongory/data_converter.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Temp Description
+module Mongory
+  DataConverter = Object.new
+  DataConverter.singleton_class.class_eval do
+    def convert(data)
+      registry.each do |klass, converter|
+        next unless data.is_a?(klass)
+
+        return converter.call(data)
+      end
+
+      data
+    end
+
+    def configure
+      yield self
+    end
+
+    def register(klass, converter = nil, &block)
+      raise 'converter or block is required.' if [converter, block].compact.empty?
+      raise 'A class or module is reuqired.' unless klass.is_a?(Module)
+
+      if converter.is_a?(Symbol)
+        register(klass, &converter)
+      elsif block.is_a?(Proc)
+        registry.unshift([klass, block])
+      else
+        raise 'Support Symbol and block only.'
+      end
+    end
+
+    private
+
+    def registry
+      @registry ||= []
+    end
+  end
+
+  DataConverter.configure do |c|
+    c.register(Hash) do |x|
+      x.transform_keys(&:to_s)
+    end
+
+    [Symbol, Date].each do |klass|
+      c.register(klass, :to_s)
+    end
+    [Time, DateTime].each do |klass|
+      c.register(klass, :iso8601)
+    end
+  end
+end

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -28,6 +28,7 @@ module Mongory
       private
 
       def dig_value(record)
+        record = DataConverter.convert(record)
         case record
         when Hash
           record.fetch(@key, KEY_NOT_FOUND)

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -33,7 +33,7 @@ module Mongory
           record.fetch(@key, KEY_NOT_FOUND)
         when Array
           record[@key]
-        when *CLASSES_NOT_ALLOW_TO_DIG
+        when KEY_NOT_FOUND, *CLASSES_NOT_ALLOW_TO_DIG
           KEY_NOT_FOUND
         else
           return KEY_NOT_FOUND unless record.respond_to?(:[])

--- a/lib/mongory/query_matcher.rb
+++ b/lib/mongory/query_matcher.rb
@@ -8,7 +8,7 @@ module Mongory
     include Mongory::Utils
 
     def initialize(condition)
-      @condition = deep_convert(condition.__expand_complex__)
+      @condition = deep_convert_condition(condition.__expand_complex__)
     end
 
     def match?(record)
@@ -28,6 +28,35 @@ module Mongory
 
     define_instance_cache_method(:data_converter) do
       Mongory.config.data_converter
+    end
+
+    private
+
+    def deep_convert_condition(obj)
+      case obj
+      when Hash
+        convert_hash(obj)
+      when Array
+        obj.map { |v| deep_convert_condition(v) }
+      when Symbol, Date
+        obj.to_s
+      when Time, DateTime
+        obj.iso8601
+      when Regexp
+        { '$regex' => obj.source }
+      else
+        obj
+      end
+    end
+
+    def convert_hash(hash)
+      hash.each_with_object({}) do |(k, v), result|
+        *keys, last_key = k.to_s.split('.')
+        last_hash = keys.reduce(result) do |res, key|
+          res[key] ||= {}
+        end
+        last_hash[last_key] = deep_convert_condition(v)
+      end
     end
   end
 end

--- a/lib/mongory/query_matcher.rb
+++ b/lib/mongory/query_matcher.rb
@@ -11,21 +11,6 @@ module Mongory
       super(deep_convert_condition(condition.__expand_complex__))
     end
 
-    def match?(record)
-      super(normalize_record(record))
-    end
-
-    def normalize_record(record)
-      return record.send(data_converter) if data_converter.is_a?(Symbol) && record.respond_to?(data_converter)
-      return data_converter.call(record) if data_converter.is_a?(Proc)
-
-      deep_convert(record)
-    end
-
-    define_instance_cache_method(:data_converter) do
-      Mongory.config.data_converter
-    end
-
     private
 
     def deep_convert_condition(obj)

--- a/lib/mongory/query_matcher.rb
+++ b/lib/mongory/query_matcher.rb
@@ -4,15 +4,15 @@ require_relative 'utils'
 
 module Mongory
   # Temp Description
-  class QueryMatcher
+  class QueryMatcher < Matchers::DefaultMatcher
     include Mongory::Utils
 
     def initialize(condition)
-      @condition = deep_convert_condition(condition.__expand_complex__)
+      super(deep_convert_condition(condition.__expand_complex__))
     end
 
     def match?(record)
-      default_matcher.match?(normalize_record(record))
+      super(normalize_record(record))
     end
 
     def normalize_record(record)
@@ -20,10 +20,6 @@ module Mongory
       return data_converter.call(record) if data_converter.is_a?(Proc)
 
       deep_convert(record)
-    end
-
-    define_instance_cache_method(:default_matcher) do
-      Mongory::Matchers::DefaultMatcher.new(@condition)
     end
 
     define_instance_cache_method(:data_converter) do

--- a/lib/mongory/utils.rb
+++ b/lib/mongory/utils.rb
@@ -10,25 +10,6 @@ module Mongory
       super
     end
 
-    def deep_convert(obj)
-      case obj
-      when Hash
-        obj.each_with_object({}) do |(k, v), result|
-          result[k.to_s] = deep_convert(v)
-        end
-      when Array
-        obj.map { |v| deep_convert(v) }
-      when Symbol, Date
-        obj.to_s
-      when Time, DateTime
-        obj.iso8601
-      when Regexp
-        { '$regex' => obj.source }
-      else
-        obj
-      end
-    end
-
     def present?(obj)
       !blank?(obj)
     end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.3.4'
+  VERSION = '1.4.0'
 end

--- a/spec/data_converter_spec.rb
+++ b/spec/data_converter_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Mongory::DataConverter do
+  subject { described_class }
+
+  describe 'interface safety' do
+    it 'cannot be instantiated with .new' do
+      expect { described_class.new }.to raise_error(NoMethodError)
+    end
+
+    it 'cannot be included as a module' do
+      expect { Class.new.include(described_class) }.to raise_error(TypeError)
+    end
+  end
+
+  describe '#convert' do
+    context 'when converting primitive types' do
+      it 'returns string for symbol' do
+        expect(subject.convert(:status)).to eq 'status'
+      end
+
+      it 'returns string for date' do
+        date = Date.new(2024, 4, 5)
+        expect(subject.convert(date)).to eq '2024-04-05'
+      end
+
+      it 'returns ISO8601 for time' do
+        time = Time.new(2024, 4, 5, 12, 30, 0)
+        expect(subject.convert(time)).to eq time.iso8601
+      end
+    end
+
+    context 'when converting hashes' do
+      let(:input) { { key: Date.new(2025, 1, 1) } }
+
+      it 'converts keys and values recursively' do
+        expect(subject.convert(input)).to eq({ 'key' => Date.new(2025, 1, 1) })
+      end
+    end
+
+    context 'when no conversion is registered' do
+      it 'returns the original object' do
+        obj = Object.new
+        expect(subject.convert(obj)).to equal(obj)
+      end
+    end
+  end
+
+  describe '#register and override behavior' do
+    let(:klass) { Struct.new(:val) }
+
+    before do
+      subject.register(klass) { |x| "original:#{x.val}" }
+    end
+
+    it 'uses the most recently registered converter' do
+      instance = klass.new('foo')
+      expect(subject.convert(instance)).to eq('original:foo')
+
+      subject.register(klass) { |x| "new:#{x.val.upcase}" }
+      expect(subject.convert(instance)).to eq('new:FOO')
+    end
+  end
+end

--- a/spec/query_matcher_spec.rb
+++ b/spec/query_matcher_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe Mongory::QueryMatcher, type: :model do
           it { is_expected.not_to be_match(anything) }
         end
 
+        context 'with dot key' do
+          let(:condition) do
+            {
+              'do.you.want.to.build.a.snow.man': 'No!'
+            }
+          end
+
+          it {
+            is_expected.to be_match(name: anything,
+                                    do: { you: { want: { to: { build: { a: { snow: { man: 'No!' } } } } } } })
+          }
+          it {
+            is_expected.not_to be_match(name: anything,
+                                        do: { you: { want: { to: { build: { a: { snow: { man: 'Yes!' } } } } } } })
+          }
+          it { is_expected.not_to be_match(anything) }
+        end
+
         context 'with nil' do
           let(:condition) do
             {

--- a/spec/query_matcher_spec.rb
+++ b/spec/query_matcher_spec.rb
@@ -3,14 +3,18 @@
 require 'mongory'
 
 class DummyModel
-  include Mongory::Utils
-
   def initialize(attributes)
-    @attributes = deep_convert(attributes)
+    @attributes = attributes
   end
 
   def as_json(*)
     @attributes
+  end
+end
+
+Mongory.data_converter.configure do |c|
+  c.register(DummyModel) do |model|
+    c.convert(model.as_json)
   end
 end
 


### PR DESCRIPTION
1. Separate the condition conversion logic, also support dot key
2. QueryMatcher inherit from DefaultMatcher to reduce dispatch layer
    - Changed QueryMatcher to inherit directly from DefaultMatcher
    - Eliminates the need to create a separate default matcher instance internally
    - Simplifies match? logic and improves matcher tree traceability
3. Normalize only top-level record keys before matching
    - Introduced Mongory::DataConverter as a singleton normalization utility
    - Automatically converts hash keys to strings for consistent field access
    - Skips deep conversion to avoid performance overhead on large records
    - Prevents new/include usage to enforce singleton behavior
    - Allows custom conversion via .register for user-defined types