### PR TITLE
feat(debugger): add match-level tracing with indent-based debug output

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,6 @@ Lint/StructNewOverride:
 
 Style/Proc:
   Enabled: false
+
+Lint/RescueException:
+  Enabled: false

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -29,5 +29,9 @@ module Mongory
     Converters::ConditionConverter
   end
 
+  def self.debugger
+    Utils::Debugger
+  end
+
   class Error < StandardError; end
 end

--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -22,7 +22,25 @@ module Mongory
         check_validity!
       end
 
-      def match?(*); end
+      def match(*); end
+
+      def match?(record)
+        match(record)
+      end
+
+      alias_method :regular_match, :match?
+
+      def debug_match(record)
+        Debugger.indent_level += 1
+        result = match(record)
+        puts (' ' * Debugger.indent_level * 2) + display(record, result)
+        result
+      rescue Exception
+        Debugger.indent_level = 1
+        raise
+      ensure
+        Debugger.indent_level -= 1
+      end
 
       private
 
@@ -30,6 +48,15 @@ module Mongory
 
       def normalize(record)
         record == KEY_NOT_FOUND ? nil : record
+      end
+
+      def display(record, result)
+        result = result ? "\e[30;42mMatched\e[0m" : "\e[30;41mDismatch\e[0m"
+
+        "#{self.class} => " \
+          "result: #{result}, " \
+          "condition: #{@condition.inspect}, " \
+          "record: #{record.inspect}"
       end
     end
   end

--- a/lib/mongory/matchers/abstract_multi_matcher.rb
+++ b/lib/mongory/matchers/abstract_multi_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Abstract class
     class AbstractMultiMatcher < AbstractMatcher
-      def match?(record)
+      def match(record)
         record = preprocess(record)
         matchers.send(operator) do |matcher|
           matcher.match?(record)

--- a/lib/mongory/matchers/abstract_operator_matcher.rb
+++ b/lib/mongory/matchers/abstract_operator_matcher.rb
@@ -7,7 +7,7 @@ module Mongory
     class AbstractOperatorMatcher < AbstractMatcher
       BOOLEAN_VALUES = [true, false].freeze
 
-      def match?(record)
+      def match(record)
         preprocess(record).send(operator, @condition)
       rescue StandardError
         false

--- a/lib/mongory/matchers/collection_matcher.rb
+++ b/lib/mongory/matchers/collection_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Temp Description
     class CollectionMatcher < AbstractMultiMatcher
-      def match?(collection)
+      def match(collection)
         return super if @condition.is_a?(Hash)
 
         collection.include?(@condition)

--- a/lib/mongory/matchers/default_matcher.rb
+++ b/lib/mongory/matchers/default_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Temp Description
     class DefaultMatcher < AbstractMatcher
-      def match?(record)
+      def match(record)
         record = Mongory.data_converter.convert(record) unless @ignore_convert
         if @condition == record
           true

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -21,7 +21,7 @@ module Mongory
         @key = key
       end
 
-      def match?(record)
+      def match(record)
         super(dig_value(record))
       end
 
@@ -40,6 +40,16 @@ module Mongory
 
           record[@key]
         end
+      end
+
+      def display(record, result)
+        result = result ? "\e[30;42mMatched\e[0m" : "\e[30;41mDismatch\e[0m"
+
+        "#{self.class} => " \
+          "result: #{result}, " \
+          "condition: #{@condition.inspect}, " \
+          "key: #{@key.inspect}, " \
+          "record: #{record.inspect}"
       end
     end
   end

--- a/lib/mongory/matchers/elem_match_matcher.rb
+++ b/lib/mongory/matchers/elem_match_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Temp Description
     class ElemMatchMatcher < DefaultMatcher
-      def match?(collection)
+      def match(collection)
         return false unless collection.is_a?(Array)
 
         collection.any? do |record|

--- a/lib/mongory/matchers/in_matcher.rb
+++ b/lib/mongory/matchers/in_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Temp Description
     class InMatcher < AbstractMatcher
-      def match?(record)
+      def match(record)
         present?(@condition & Array(record))
       end
 

--- a/lib/mongory/matchers/nin_matcher.rb
+++ b/lib/mongory/matchers/nin_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Temp Description
     class NinMatcher < AbstractMatcher
-      def match?(record)
+      def match(record)
         blank?(@condition & Array(record))
       end
 

--- a/lib/mongory/matchers/not_matcher.rb
+++ b/lib/mongory/matchers/not_matcher.rb
@@ -5,7 +5,7 @@ module Mongory
   module Matchers
     # Temp Description
     class NotMatcher < DefaultMatcher
-      def match?(record)
+      def match(record)
         !super(record)
       end
     end

--- a/lib/mongory/utils.rb
+++ b/lib/mongory/utils.rb
@@ -2,6 +2,7 @@
 
 require 'date'
 require_relative 'utils/singleton_marker'
+require_relative 'utils/debugger'
 
 module Mongory
   # Temp Description

--- a/lib/mongory/utils/debugger.rb
+++ b/lib/mongory/utils/debugger.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Mongory
+  # Temp Description
+  module Utils
+    Debugger = Object.new
+    Debugger.instance_eval do
+      class << self
+        attr_accessor :indent_level
+      end
+
+      @indent_level = 0
+
+      def enable
+        Matchers::AbstractMatcher.alias_method :match?, :debug_match
+      end
+
+      def disable
+        Matchers::AbstractMatcher.alias_method :match?, :regular_match
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Introduced Mongory::Utils::Debugger as a singleton debugging utility
- Swappable matcher behavior via method aliasing (match? → debug_match)
- Enabled nested match tracing with configurable indentation levels
- `AbstractMatcher` now defines `regular_match` and `debug_match`
- Trace output includes matcher class, result (Matched/Dismatch), condition and record
- Uses ANSI color codes for clearer CLI visibility
- Hook is globally toggleable via `Mongory.debugger.enable` / `Mongory.debugger.disable`