### PR TITLE
docs(matchers): add complete class and method documentation for all core matchers

### DIFF
--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -1,20 +1,37 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Abstract class
+    # AbstractMatcher is the base class for all matchers in Mongory.
+    # It defines a common interface (`#match?`) and provides shared behavior
+    # such as condition storage, optional conversion handling, and debugging output.
+    #
+    # Subclasses are expected to implement `#match(record)` to define their matching logic.
+    # This class also supports caching of lazily-built matchers via `define_matcher`.
+    #
+    # @abstract
     class AbstractMatcher
       include Utils
 
+      # Sentinel value used to represent missing keys when traversing nested hashes.
       KEY_NOT_FOUND = SingletonMarker.new('KEY_NOT_FOUND')
 
+      # Defines a lazily-evaluated matcher accessor with instance-level caching.
+      #
+      # @param name [Symbol] the name of the matcher (e.g., :collection)
+      # @yield the block that constructs the matcher instance
+      # @return [void]
       def self.define_matcher(name, &block)
         define_instance_cache_method(:"#{name}_matcher", &block)
       end
 
+      # @return [Object] the raw condition this matcher was initialized with
       attr_reader :condition
 
+      # Initializes the matcher with a condition and optional conversion control.
+      #
+      # @param condition [Object] the condition to match against
+      # @param ignore_convert [Boolean] whether to skip data conversion (default: false)
       def initialize(condition, ignore_convert: false)
         @condition = condition
         @ignore_convert = ignore_convert
@@ -22,14 +39,29 @@ module Mongory
         check_validity!
       end
 
+      # Performs the actual match logic.
+      # Subclasses must override this method.
+      #
+      # @param record [Object] the input record to test
+      # @return [Boolean] whether the record matches the condition
       def match(*); end
 
+      # Wrapper for `#match` with clearer semantics.
+      #
+      # @param record [Object] the input record to test
+      # @return [Boolean] whether the record matches the condition
       def match?(record)
         match(record)
       end
 
+      # Provides an alias to `#match?` for internal delegation.
       alias_method :regular_match, :match?
 
+      # Evaluates the match with debugging output.
+      # Increments indent level and prints visual result with colors.
+      #
+      # @param record [Object] the input record to test
+      # @return [Boolean] whether the match succeeded
       def debug_match(record)
         Debugger.indent_level += 1
         result = match(record)
@@ -44,12 +76,27 @@ module Mongory
 
       private
 
+      # Hook for subclasses to validate the given condition.
+      # Default is no-op. Should raise if condition is malformed.
+      #
+      # @return [void]
       def check_validity!; end
 
+      # Normalizes a potentially missing record value.
+      # Converts sentinel `KEY_NOT_FOUND` to nil.
+      #
+      # @param record [Object] the input value
+      # @return [Object, nil] the normalized value
       def normalize(record)
         record == KEY_NOT_FOUND ? nil : record
       end
 
+      # Formats a debug string for match output.
+      # Uses ANSI escape codes to highlight matched vs. mismatched records.
+      #
+      # @param record [Object] the record being tested
+      # @param result [Boolean] whether the match succeeded
+      # @return [String] the formatted output string
       def display(record, result)
         result = result ? "\e[30;42mMatched\e[0m" : "\e[30;41mDismatch\e[0m"
 

--- a/lib/mongory/matchers/abstract_multi_matcher.rb
+++ b/lib/mongory/matchers/abstract_multi_matcher.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Abstract class
+    # AbstractMultiMatcher is an abstract base class for matchers that operate
+    # on multiple subconditions. It provides a generic match loop that applies
+    # a logical operator (e.g., `all?`, `any?`) over a list of sub-matchers.
+    #
+    # Subclasses must define two methods:
+    #   - `#build_sub_matcher`: how to construct a matcher from each condition
+    #   - `#operator`: which enumerator method to use (e.g., :all?, :any?)
+    #
+    # Sub-matchers are cached using `define_instance_cache_method` to prevent
+    # repeated construction.
+    #
+    # @abstract
+    # @see AbstractMatcher
     class AbstractMultiMatcher < AbstractMatcher
+      # Performs matching over all sub-matchers using the specified operator.
+      # The input record may be preprocessed first (e.g., for normalization).
+      #
+      # @param record [Object] the record to match
+      # @return [Boolean] whether the combined result of sub-matchers satisfies the condition
       def match(record)
         record = preprocess(record)
         matchers.send(operator) do |matcher|
@@ -12,15 +28,34 @@ module Mongory
         end
       end
 
+      # Lazily builds and caches the array of sub-matchers.
+      # Subclasses provide the implementation of `#build_sub_matcher`.
+      # Duplicate matchers (by condition) are removed to avoid redundancy.
+      #
+      # @return [Array<AbstractMatcher>] list of sub-matchers
       define_instance_cache_method(:matchers) do
         @condition.map(&method(:build_sub_matcher)).uniq(&:condition)
       end
 
+      # Optional hook for subclasses to transform the input record before matching.
+      # Default implementation returns the record unchanged.
+      #
+      # @param record [Object] the input record
+      # @return [Object] the transformed or original record
       def preprocess(record)
         record
       end
 
+      # Abstract method to define how each subcondition should be turned into a matcher.
+      #
+      # @param args [Array] the inputs needed to construct a matcher
+      # @return [AbstractMatcher] a matcher instance for the subcondition
       def build_sub_matcher(*); end
+
+      # Abstract method to specify the combining operator for sub-matchers.
+      # Must return a valid enumerable method name (e.g., :all?, :any?).
+      #
+      # @return [Symbol] the operator method to apply over matchers
       def operator; end
     end
   end

--- a/lib/mongory/matchers/abstract_operator_matcher.rb
+++ b/lib/mongory/matchers/abstract_operator_matcher.rb
@@ -1,22 +1,47 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Abstract class
+    # AbstractOperatorMatcher is a base class for matchers that apply a binary
+    # operator (e.g., `==`, `<`, `>` etc.) between the record and the condition.
+    #
+    # This class assumes that the match logic consists of:
+    #   preprocess(record).send(operator, condition)
+    # and provides a fallback behavior for invalid comparisons.
+    #
+    # Subclasses must implement `#operator` and may override `#preprocess`
+    # to normalize or cast the record before comparison.
+    #
+    # @abstract
+    # @see AbstractMatcher
     class AbstractOperatorMatcher < AbstractMatcher
+      # A list of Boolean values used for type guarding in some subclasses.
       BOOLEAN_VALUES = [true, false].freeze
 
+      # Applies the binary operator to the preprocessed record and condition.
+      # If an error is raised (e.g., undefined comparison), the match fails.
+      #
+      # @param record [Object] the input record to test
+      # @return [Boolean] the result of record <operator> condition
       def match(record)
         preprocess(record).send(operator, @condition)
       rescue StandardError
         false
       end
 
+      # Hook for subclasses to transform the record before comparison.
+      # Default behavior normalizes KEY_NOT_FOUND to nil.
+      #
+      # @param record [Object] the raw record value
+      # @return [Object] the transformed value
       def preprocess(record)
         normalize(record)
       end
 
+      # Returns the Ruby operator symbol to be used in comparison.
+      # Must be implemented by subclasses (e.g., :==, :<, :>=)
+      #
+      # @return [Symbol] the comparison operator
       def operator; end
     end
   end

--- a/lib/mongory/matchers/collection_matcher.rb
+++ b/lib/mongory/matchers/collection_matcher.rb
@@ -1,20 +1,51 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # CollectionMatcher is responsible for matching an array (or array-like object)
+    # against a given condition. It supports both exact element matching and
+    # more complex nested logic using an `ElemMatchMatcher`.
+    #
+    # If the condition is not a Hash, it falls back to simple inclusion check (`Array#include?`).
+    # If the condition is a Hash, each key/value is used to build an appropriate matcher.
+    #
+    # Submatchers are built dynamically depending on whether the key is an integer index,
+    # numeric string, operator, or a regular hash field.
+    #
+    # @example
+    #   matcher = CollectionMatcher.new({ 0 => { :$gt => 5 }, status: "active" })
+    #   matcher.match?([10, { status: "active" }]) #=> true if all conditions are satisfied
+    #
+    # @see AbstractMultiMatcher
+    # @see ElemMatchMatcher
+    # @see DigValueMatcher
     class CollectionMatcher < AbstractMultiMatcher
+      # Custom matching logic: if condition is not a hash, do inclusion check.
+      # Otherwise, fallback to the parent AbstractMultiMatcher#match logic.
+      #
+      # @param collection [Object] the collection to be tested (usually an Array)
+      # @return [Boolean] whether the condition matches the collection
       def match(collection)
         return super if @condition.is_a?(Hash)
 
         collection.include?(@condition)
       end
 
+      # Lazily builds a shared ElemMatchMatcher used for complex field matching.
+      #
+      # @return [ElemMatchMatcher] shared matcher instance for field conditions
       define_matcher(:elem) do
         ElemMatchMatcher.new({})
       end
 
+      # Builds sub-matchers depending on the key:
+      #   - Integer or numeric string: treated as array index (DigValueMatcher)
+      #   - Operator: resolved via Matchers.lookup
+      #   - Else: merged into ElemMatchMatcher condition
+      #
+      # @param key [Object] the key from the condition hash
+      # @param value [Object] the associated condition value
+      # @return [AbstractMatcher] matcher instance for this field/operator
       def build_sub_matcher(key, value)
         case key
         when Integer
@@ -29,6 +60,9 @@ module Mongory
         end
       end
 
+      # Uses `:all?` to ensure all sub-matchers must match.
+      #
+      # @return [Symbol] the combining operator
       def operator
         :all?
       end

--- a/lib/mongory/matchers/condition_matcher.rb
+++ b/lib/mongory/matchers/condition_matcher.rb
@@ -1,10 +1,32 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # ConditionMatcher is responsible for handling field-level query conditions.
+    # It receives a Hash of key-value pairs and delegates each one to an appropriate matcher
+    # based on whether the key is a recognized operator or a data field path.
+    #
+    # Each subcondition is matched independently using the `:all?` strategy, meaning
+    # all subconditions must match for the entire ConditionMatcher to succeed.
+    #
+    # This matcher plays a central role in dispatching symbolic query conditions
+    # to the appropriate field or operator matcher.
+    #
+    # @example
+    #   matcher = ConditionMatcher.new({ age: { :$gt => 30 }, active: true })
+    #   matcher.match?(record) #=> true only if all subconditions match
+    #
+    # @see AbstractMultiMatcher
+    # @see DigValueMatcher
+    # @see Matchers.lookup
     class ConditionMatcher < AbstractMultiMatcher
+      # Constructs the appropriate submatcher for a key-value pair.
+      # If the key is a registered operator, dispatches to the corresponding matcher.
+      # Otherwise, assumes the key is a field path and uses DigValueMatcher.
+      #
+      # @param key [String] the condition key (either an operator or field name)
+      # @param value [Object] the condition value
+      # @return [AbstractMatcher] a matcher instance
       def build_sub_matcher(key, value)
         case key
         when *Matchers::OPERATOR_TO_CLASS_MAPPING.keys
@@ -14,6 +36,10 @@ module Mongory
         end
       end
 
+      # Specifies the matching strategy for all subconditions.
+      # Uses `:all?`, meaning all conditions must be satisfied.
+      #
+      # @return [Symbol] the combining operator method
       def operator
         :all?
       end

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -1,11 +1,24 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # DigValueMatcher is responsible for extracting a value from a record
+    # using a key (or index) and then delegating the match to DefaultMatcher logic.
+    #
+    # It handles nested access in structures like Hashes or Arrays, and guards
+    # against types that should not be dig into (e.g., String, Symbol, Proc).
+    #
+    # This matcher is typically used when the query refers to a specific field,
+    # like `{ age: { :$gte => 18 } }` where `:age` is passed as the dig key.
+    #
+    # @example
+    #   matcher = DigValueMatcher.new(:age, { :$gte => 18 })
+    #   matcher.match?({ age: 20 }) #=> true
+    #
+    # @see DefaultMatcher
     class DigValueMatcher < DefaultMatcher
-      # These classes are not expected to dig value but respond to :[] method
+      # A list of classes that should never be used for value digging.
+      # These typically respond to `#[]` but are semantically invalid for this context.
       CLASSES_NOT_ALLOW_TO_DIG = [
         ::String,
         ::Integer,
@@ -16,17 +29,28 @@ module Mongory
         ::Symbol
       ].freeze
 
+      # @param key [Object] the key (or index) used to dig into the record
+      # @param condition [Object] the condition to match against the extracted value
       def initialize(key, condition)
         super(condition)
         @key = key
       end
 
+      # Extracts the target value using the key and delegates to DefaultMatcher.
+      #
+      # @param record [Object] the record to match
+      # @return [Boolean] whether the extracted value matches the condition
       def match(record)
         super(dig_value(record))
       end
 
       private
 
+      # Attempts to extract the value from the given record using @key.
+      # Guards against unsupported types and returns KEY_NOT_FOUND if extraction fails.
+      #
+      # @param record [Object] the input record
+      # @return [Object] the extracted value or KEY_NOT_FOUND
       def dig_value(record)
         case record
         when Hash, Array
@@ -40,6 +64,11 @@ module Mongory
         end
       end
 
+      # Custom display logic for debugging, including colored key highlighting.
+      #
+      # @param record [Object] the input record
+      # @param result [Boolean] match result
+      # @return [String] formatted debug string
       def display(record, result)
         result = result ? "\e[30;42mMatched\e[0m" : "\e[30;41mDismatch\e[0m"
 

--- a/lib/mongory/matchers/elem_match_matcher.rb
+++ b/lib/mongory/matchers/elem_match_matcher.rb
@@ -1,10 +1,27 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # ElemMatchMatcher implements the logic for Mongo-style `$elemMatch`.
+    # It is used to determine if *any* element in an array matches the given condition.
+    #
+    # This matcher delegates element-wise comparison to DefaultMatcher,
+    # allowing nested conditions to be applied recursively.
+    #
+    # Typically used internally by CollectionMatcher when dealing with
+    # non-indexed hash-style subconditions.
+    #
+    # @example
+    #   matcher = ElemMatchMatcher.new({ status: 'active' })
+    #   matcher.match?([{ status: 'inactive' }, { status: 'active' }]) #=> true
+    #
+    # @see DefaultMatcher
     class ElemMatchMatcher < DefaultMatcher
+      # Matches true if any element in the array satisfies the condition.
+      # Falls back to false if the input is not an array.
+      #
+      # @param collection [Object] the input to be tested
+      # @return [Boolean] whether any element matches
       def match(collection)
         return false unless collection.is_a?(Array)
 

--- a/lib/mongory/matchers/eq_matcher.rb
+++ b/lib/mongory/matchers/eq_matcher.rb
@@ -1,10 +1,25 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # EqMatcher matches values using the equality operator `==`.
+    # It inherits from AbstractOperatorMatcher and defines its operator as `:==`.
+    #
+    # Used for conditions like:
+    #   { age: { :$eq => 30 } }
+    #
+    # This matcher supports any Ruby object that implements `#==`.
+    #
+    # @example
+    #   matcher = EqMatcher.new(42)
+    #   matcher.match?(42)        #=> true
+    #   matcher.match?("42")      #=> false
+    #
+    # @see AbstractOperatorMatcher
     class EqMatcher < AbstractOperatorMatcher
+      # Returns the Ruby equality operator to be used in matching.
+      #
+      # @return [Symbol] the equality operator symbol
       def operator
         :==
       end

--- a/lib/mongory/matchers/exists_matcher.rb
+++ b/lib/mongory/matchers/exists_matcher.rb
@@ -1,18 +1,43 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # ExistsMatcher implements the `$exists` operator, which checks whether a key exists.
+    #
+    # It transforms the presence (or absence) of a field into a boolean value,
+    # then compares it to the condition using the `==` operator.
+    #
+    # This matcher ensures the condition is strictly a boolean (`true` or `false`).
+    #
+    # @example
+    #   matcher = ExistsMatcher.new(true)
+    #   matcher.match?(42)              #=> true
+    #   matcher.match?(KEY_NOT_FOUND)   #=> false
+    #
+    #   matcher = ExistsMatcher.new(false)
+    #   matcher.match?(KEY_NOT_FOUND)   #=> true
+    #
+    # @see AbstractOperatorMatcher
     class ExistsMatcher < AbstractOperatorMatcher
+      # Converts the raw record value into a boolean indicating presence.
+      #
+      # @param record [Object] the value associated with the field
+      # @return [Boolean] true if the key exists, false otherwise
       def preprocess(record)
         record != KEY_NOT_FOUND
       end
 
+      # Uses Ruby's equality operator to compare presence against expected boolean.
+      #
+      # @return [Symbol] the comparison operator
       def operator
         :==
       end
 
+      # Ensures that the condition value is a valid boolean.
+      #
+      # @raise [TypeError] if condition is not true or false
+      # @return [void]
       def check_validity!
         raise TypeError, '$exists needs a boolean' unless BOOLEAN_VALUES.include?(@condition)
       end

--- a/lib/mongory/matchers/gt_matcher.rb
+++ b/lib/mongory/matchers/gt_matcher.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # GtMatcher implements the `$gt` (greater than) operator.
+    # It returns true if the record is strictly greater than the condition.
+    #
+    # Inherits core logic from AbstractOperatorMatcher, including
+    # error handling and optional preprocessing.
+    #
+    # @example
+    #   matcher = GtMatcher.new(10)
+    #   matcher.match?(15)  #=> true
+    #   matcher.match?(10)  #=> false
+    #
+    # @see AbstractOperatorMatcher
     class GtMatcher < AbstractOperatorMatcher
+      # Returns the Ruby `>` operator symbol for comparison.
+      #
+      # @return [Symbol] the greater-than operator
       def operator
         :>
       end

--- a/lib/mongory/matchers/gte_matcher.rb
+++ b/lib/mongory/matchers/gte_matcher.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # GteMatcher implements the `$gte` (greater than or equal) operator.
+    # It returns true if the record is greater than or equal to the condition value.
+    #
+    # Inherits comparison logic and error safety from AbstractOperatorMatcher.
+    #
+    # @example
+    #   matcher = GteMatcher.new(10)
+    #   matcher.match?(10)  #=> true
+    #   matcher.match?(11)  #=> true
+    #   matcher.match?(9)   #=> false
+    #
+    # @see AbstractOperatorMatcher
     class GteMatcher < AbstractOperatorMatcher
+      # Returns the Ruby `>=` operator symbol for comparison.
+      #
+      # @return [Symbol] the greater-than-or-equal operator
       def operator
         :>=
       end

--- a/lib/mongory/matchers/in_matcher.rb
+++ b/lib/mongory/matchers/in_matcher.rb
@@ -1,14 +1,35 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # InMatcher implements the `$in` operator.
+    # It checks whether the record (converted to an array) has any overlap
+    # with the condition array. This supports both scalar and array inputs.
+    #
+    # The match succeeds if there is any intersection between the condition array
+    # and the record value (or values).
+    #
+    # @example
+    #   matcher = InMatcher.new([1, 2, 3])
+    #   matcher.match?(2)        #=> true
+    #   matcher.match?([3, 4])   #=> true
+    #   matcher.match?(5)        #=> false
+    #
+    # @see AbstractMatcher
     class InMatcher < AbstractMatcher
+      # Matches if any element of the record appears in the condition array.
+      # Converts record to an array before intersecting.
+      #
+      # @param record [Object] the record value to test
+      # @return [Boolean] whether any values intersect
       def match(record)
         present?(@condition & Array(record))
       end
 
+      # Ensures the condition is an array.
+      #
+      # @raise [TypeError] if condition is not an array
+      # @return [void]
       def check_validity!
         raise TypeError, '$in needs an array' unless @condition.is_a?(Array)
       end

--- a/lib/mongory/matchers/lt_matcher.rb
+++ b/lib/mongory/matchers/lt_matcher.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # LtMatcher implements the `$lt` (less than) operator.
+    # It returns true if the record is strictly less than the condition value.
+    #
+    # This matcher inherits from AbstractOperatorMatcher and uses the `<` operator.
+    #
+    # @example
+    #   matcher = LtMatcher.new(10)
+    #   matcher.match?(9)    #=> true
+    #   matcher.match?(10)   #=> false
+    #   matcher.match?(11)   #=> false
+    #
+    # @see AbstractOperatorMatcher
     class LtMatcher < AbstractOperatorMatcher
+      # Returns the Ruby `<` operator symbol for comparison.
+      #
+      # @return [Symbol] the less-than operator
       def operator
         :<
       end

--- a/lib/mongory/matchers/lte_matcher.rb
+++ b/lib/mongory/matchers/lte_matcher.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # LteMatcher implements the `$lte` (less than or equal to) operator.
+    # It returns true if the record is less than or equal to the condition value.
+    #
+    # This matcher inherits from AbstractOperatorMatcher and uses the `<=` operator.
+    #
+    # @example
+    #   matcher = LteMatcher.new(10)
+    #   matcher.match?(9)    #=> true
+    #   matcher.match?(10)   #=> true
+    #   matcher.match?(11)   #=> false
+    #
+    # @see AbstractOperatorMatcher
     class LteMatcher < AbstractOperatorMatcher
+      # Returns the Ruby `<=` operator symbol for comparison.
+      #
+      # @return [Symbol] the less-than-or-equal operator
       def operator
         :<=
       end

--- a/lib/mongory/matchers/ne_matcher.rb
+++ b/lib/mongory/matchers/ne_matcher.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # NeMatcher implements the `$ne` (not equal) operator.
+    # It returns true if the record is *not equal* to the condition.
+    #
+    # This matcher inherits its logic from AbstractOperatorMatcher
+    # and uses Ruby's `!=` operator for comparison.
+    #
+    # @example
+    #   matcher = NeMatcher.new(42)
+    #   matcher.match?(41)  #=> true
+    #   matcher.match?(42)  #=> false
+    #
+    # @see AbstractOperatorMatcher
     class NeMatcher < AbstractOperatorMatcher
+      # Returns the Ruby `!=` operator symbol for comparison.
+      #
+      # @return [Symbol] the not-equal operator
       def operator
         :!=
       end

--- a/lib/mongory/matchers/nin_matcher.rb
+++ b/lib/mongory/matchers/nin_matcher.rb
@@ -1,14 +1,35 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # NinMatcher implements the `$nin` (not in) operator.
+    # It returns true if *none* of the record's values appear in the condition array.
+    # The record is cast to an array to ensure uniform behavior across types.
+    #
+    # This matcher is the logical opposite of InMatcher.
+    #
+    # @example
+    #   matcher = NinMatcher.new([1, 2, 3])
+    #   matcher.match?(4)        #=> true
+    #   matcher.match?(2)        #=> false
+    #   matcher.match?([4, 5])   #=> true
+    #   matcher.match?([2, 4])   #=> false
+    #
+    # @see InMatcher
+    # @see AbstractMatcher
     class NinMatcher < AbstractMatcher
+      # Matches true if the record has no elements in common with the condition array.
+      #
+      # @param record [Object] the value to be tested
+      # @return [Boolean] whether the record is disjoint from the condition array
       def match(record)
         blank?(@condition & Array(record))
       end
 
+      # Ensures the condition is a valid array.
+      #
+      # @raise [TypeError] if the condition is not an array
+      # @return [void]
       def check_validity!
         raise TypeError, '$nin needs an array' unless @condition.is_a?(Array)
       end

--- a/lib/mongory/matchers/not_matcher.rb
+++ b/lib/mongory/matchers/not_matcher.rb
@@ -1,10 +1,26 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # NotMatcher implements the `$not` logical operator.
+    # It returns true if the wrapped matcher fails, effectively inverting the result.
+    #
+    # It delegates to DefaultMatcher and simply negates the outcome.
+    #
+    # This allows constructs like:
+    #   { age: { :$not => { :$gte => 30 } } }
+    #
+    # @example
+    #   matcher = NotMatcher.new({ :$gte => 10 })
+    #   matcher.match?(5)    #=> true
+    #   matcher.match?(15)   #=> false
+    #
+    # @see DefaultMatcher
     class NotMatcher < DefaultMatcher
+      # Inverts the result of DefaultMatcher#match.
+      #
+      # @param record [Object] the value to test
+      # @return [Boolean] whether the negated condition is satisfied
       def match(record)
         !super(record)
       end

--- a/lib/mongory/matchers/or_matcher.rb
+++ b/lib/mongory/matchers/or_matcher.rb
@@ -1,24 +1,57 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # OrMatcher implements the `$or` logical operator.
+    # It evaluates an array of subconditions and returns true
+    # if *any one* of them matches.
+    #
+    # Each subcondition is handled by a DefaultMatcher with conversion disabled,
+    # since the parent matcher already manages data conversion.
+    #
+    # This matcher inherits submatcher dispatch and evaluation logic
+    # from AbstractMultiMatcher.
+    #
+    # @example
+    #   matcher = OrMatcher.new([
+    #     { age: { :$lt => 18 } },
+    #     { admin: true }
+    #   ])
+    #   matcher.match?(record) #=> true if either condition matches
+    #
+    # @see AbstractMultiMatcher
+    # @see DefaultMatcher
     class OrMatcher < AbstractMultiMatcher
+      # Constructs a DefaultMatcher for each subcondition.
+      # Conversion is disabled to avoid double-processing.
+      #
+      # @param condition [Object] a subcondition to be wrapped
+      # @return [DefaultMatcher] a matcher for this condition
       def build_sub_matcher(condition)
         DefaultMatcher.new(condition, ignore_convert: true)
       end
 
+      # Uses `:any?` to return true if any submatcher passes.
+      #
+      # @return [Symbol] the combining operator
       def operator
         :any?
       end
 
+      # Optionally applies preprocessing unless disabled.
+      #
+      # @param record [Object] the record to be matched
+      # @return [Object] the converted or raw record
       def preprocess(record)
         return record if @ignore_convert
 
         Mongory.data_converter.convert(record)
       end
 
+      # Ensures the condition is an array of subconditions.
+      #
+      # @raise [TypeError] if condition is not an array
+      # @return [void]
       def check_validity!
         raise TypeError, '$or needs an array' unless @condition.is_a?(Array)
       end

--- a/lib/mongory/matchers/present_matcher.rb
+++ b/lib/mongory/matchers/present_matcher.rb
@@ -1,18 +1,46 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # PresentMatcher implements the `$present` operator.
+    # It returns true if the record value is considered "present"
+    # (i.e., not nil, not empty, not KEY_NOT_FOUND), and matches
+    # the expected boolean condition.
+    #
+    # This is similar to `$exists`, but evaluates truthiness
+    # of the value instead of mere existence.
+    #
+    # @example
+    #   matcher = PresentMatcher.new(true)
+    #   matcher.match?('hello')     #=> true
+    #   matcher.match?(nil)         #=> false
+    #   matcher.match?([])          #=> false
+    #
+    #   matcher = PresentMatcher.new(false)
+    #   matcher.match?(nil)         #=> true
+    #
+    # @see AbstractOperatorMatcher
     class PresentMatcher < AbstractOperatorMatcher
+      # Transforms the record into a boolean presence flag
+      # before applying comparison.
+      #
+      # @param record [Object] the original value
+      # @return [Boolean] whether the value is present
       def preprocess(record)
         present?(super)
       end
 
+      # Uses Ruby `==` to compare the presence result to the expected boolean.
+      #
+      # @return [Symbol] the equality operator
       def operator
         :==
       end
 
+      # Ensures that the condition value is a boolean.
+      #
+      # @raise [TypeError] if condition is not true or false
+      # @return [void]
       def check_validity!
         raise TypeError, '$present needs a boolean' unless BOOLEAN_VALUES.include?(@condition)
       end

--- a/lib/mongory/matchers/regex_matcher.rb
+++ b/lib/mongory/matchers/regex_matcher.rb
@@ -1,20 +1,47 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
   module Matchers
-    # Temp Description
+    # RegexMatcher implements the `$regex` operator.
+    # It returns true if the record string matches the given pattern string.
+    #
+    # Although `@condition` is passed as a string (due to ValueConverter converting
+    # Regexp into its `source`), Ruby's `String#match?(String)` internally treats it
+    # as a regular expression pattern. This allows direct use without explicit Regexp.new.
+    #
+    # This matcher ensures the record is a String before attempting the match.
+    #
+    # @example
+    #   matcher = RegexMatcher.new('^foo')
+    #   matcher.match?('foobar')   #=> true
+    #   matcher.match?('barfoo')   #=> false
+    #
+    # @note `@condition` is a pattern string, not a full Regexp object.
+    # @see AbstractOperatorMatcher
+    # @see Mongory::Converters::ValueConverter
     class RegexMatcher < AbstractOperatorMatcher
+      # Uses `:match?` as the operator to invoke on the record string.
+      #
+      # @return [Symbol] the match? method symbol
       def operator
         :match?
       end
 
+      # Ensures the record is a string before applying regex.
+      # If not, coerces to empty string to ensure match fails safely.
+      #
+      # @param record [Object] the raw input
+      # @return [String] a safe string to match against
       def preprocess(record)
         return '' unless record.is_a?(String)
 
         record
       end
 
+      # Ensures the condition is a valid string (not a Regexp).
+      #
+      # @raise [TypeError] if condition is not a string
+      # @return [void]
       def check_validity!
         raise TypeError, '$regex needs a string' unless @condition.is_a?(String)
       end


### PR DESCRIPTION
This pull request adds comprehensive YARD-style documentation to all matcher classes within the `Mongory::Matchers` module.

### Coverage

The following matcher types have been fully documented:

- 🔹 Base architecture:
  - `AbstractMatcher`
  - `AbstractMultiMatcher`
  - `AbstractOperatorMatcher`

- 🔹 Logical matchers:
  - `AndMatcher`
  - `OrMatcher`
  - `NotMatcher`

- 🔹 Operator matchers:
  - `EqMatcher` `$eq`
  - `NeMatcher` `$ne`
  - `GtMatcher` `$gt`
  - `GteMatcher` `$gte`
  - `LtMatcher` `$lt`
  - `LteMatcher` `$lte`
  - `InMatcher` `$in`
  - `NinMatcher` `$nin`
  - `RegexMatcher` `$regex`
  - `ExistsMatcher` `$exists`
  - `PresentMatcher` `$present`

- 🔹 Field & structure matchers:
  - `ConditionMatcher`
  - `DefaultMatcher`
  - `DigValueMatcher`
  - `CollectionMatcher`
  - `ElemMatchMatcher`

### Notes

- All methods are annotated with param types, return types, and behavior descriptions.
- Special care has been taken to clarify delegation chains and matcher composition behaviors.
- `RegexMatcher` includes notes on `ValueConverter` integration and the use of `String#match?` with pattern strings.

This documentation will serve as a foundation for public-facing documentation, developer onboarding, and future feature expansion.
