### PR TITLE
Release/1.6.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,3 +62,6 @@ Lint/RescueException:
 
 Naming/AccessorMethodName:
   Enabled: false
+
+Naming/PredicateName:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,27 @@
 ## [1.6.0] - 2025-04-11
 
 ### Added
-- **Custom Operator: `$every`**  
+- **Custom Operator: `$every`**
   Added support for `$every`, a new matcher that succeeds only if *all* elements in an array satisfy the condition.
-- **Custom Error Class: `Mongory::TypeError`**  
+- **Custom Error Class: `Mongory::TypeError`**
   Replaces Ruby's `TypeError` for internal validation, enabling cleaner and safer error handling.
-- **Internal API: `SingletonBuilder`**  
+- **Internal API: `SingletonBuilder`**
   Introduced a unified abstraction for building singleton converters and utilities (used by `Debugger`, all Converters, etc.).
 
 ### Changed
-- **Unified Matcher Construction**  
+- **Unified Matcher Construction**
   All matchers now use `.build(...)` instead of `.new(...)` for consistent instantiation.
-- **Simplified Matcher Dispatch**  
+- **Simplified Matcher Dispatch**
   Multi-matchers (`$and`, `$or`, etc.) now unwrap themselves when only one submatcher is present.
-- **Centralized Matcher Responsibility**  
+- **Centralized Matcher Responsibility**
   `ConditionMatcher` replaces `DefaultMatcher` as the default dispatcher for query conditions.
-- **Consistent Data Conversion**  
+- **Consistent Data Conversion**
   All nested matchers (e.g. `DigValueMatcher`, `ElemMatchMatcher`) now apply `data_converter` at match-time.
 
 ### Fixed
-- **Validation Improvements**  
+- **Validation Improvements**
   Introduced `deep_check_validity!` to ensure all nested matchers are properly verified.
-- **Edge Case Consistency**  
+- **Edge Case Consistency**
   Cleaner fallback handling and key traversal behavior under complex or mixed-type query structures.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
-## [Unreleased]
+## [1.6.1] - 2025-04-11
 
-...
+### Added
+
+- **Rails Integration via Railtie**  
+  Mongory now auto-integrates with Rails if present, using a new `Mongory::Railtie` and `RailsPatch` module.
+
+- **Mongoid Integration Module**  
+  Added `mongory/mongoid` which registers `Mongoid::Criteria::Queryable::Key` for symbolic query operators (e.g. `:age.gt`).
+
+- **Conditional Auto-Require**  
+  `mongory.rb` now conditionally requires `rails` and `mongoid` integration modules when Rails or Mongoid is detected.
+
+- **YARD Documentation**  
+  Improved YARD docstrings for all public APIs, including `QueryOperator`, `InstallGenerator`, and matchers.
+
+### Changed
+
+- **Generator Initializer Cleanup**  
+  Removed direct Mongoid-specific converter registration from generator output. This logic is now encapsulated in `mongory/mongoid.rb`.
+
+- **Improved Symbol DSL Activation**  
+  Symbol snippets (`:age.gt => 30`) are now opt-in, via `Mongory.enable_symbol_snippets!`, and properly isolated from default runtime.
+
+- **Safer Core Patch for present?/blank?**  
+  When in Rails, Mongory will use `Object#present?` and `Object#blank?` instead of internal implementations, for better semantic consistency.
 
 ## [1.6.0] - 2025-04-11
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.6.0)
+    mongory (1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.5.0)
+    mongory (1.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ A Mongo-like in-memory query DSL for Ruby.
 Mongory lets you filter and query in-memory collections using syntax and semantics similar to MongoDB. It is designed for expressive chaining, symbolic operators, and composable matchers.
 
 ## Installation
+### Rails Generator
+
+You can install a starter configuration with:
+
+```bash
+rails g mongory:install
+```
+
+This will generate `config/initializers/mongory.rb` and set up:
+- Optional symbol operator snippets (e.g. `:age.gt => 18`)
+- Class registration (e.g. `Array`, `ActiveRecord::Relation`, etc.)
+- Custom value/key converters for your ORM
 
 Add to your Gemfile:
 
@@ -48,7 +60,11 @@ puts result
 | Boolean      | `$and`, `$or`, `$not`               |
 | Pattern      | `$regex`                            |
 | Presence     | `$exists`, `$present`               |
-| Nested Match | `$elemMatch`                        |
+| Nested Match | `$elemMatch`, `$every`                      |
+
+Mongory extension:
+- `$present` - checks if the record is not empty or false, nil
+- `$every` – checks that all elements in an array match the condition
 
 Operators can be chained from symbols:
 
@@ -57,6 +73,17 @@ Operators can be chained from symbols:
 ```
 
 ## Query API Reference
+### Registering Models
+
+To allow calling `.mongory` on collections, use `register`:
+
+```ruby
+Mongory.register(Array)
+Mongory.register(ActiveRecord::Relation)
+User.where(status: 'active').mongory.where(:age.gte => 18, :name.regex => "^S.+")
+```
+
+This injects a `.mongory` method via an internal extension module.
 
 - `.where(cond)` → adds `$and` condition
 - `.or(*conds)` → adds `$or` conditions

--- a/lib/generators/mongory/install/install_generator.rb
+++ b/lib/generators/mongory/install/install_generator.rb
@@ -1,14 +1,25 @@
-# lib/generators/mongory/install/install_generator.rb
 # frozen_string_literal: true
 
 require 'bundler'
 
 module Mongory
   module Generators
-    # Temp description
+    # Generates a Mongory initializer file with suggested configuration
+    # based on detected ORMs (ActiveRecord, Mongoid, Sequel).
+    #
+    # This is intended to be used via:
+    #   rails generate mongory:install
+    #
+    # @example
+    #   # Will generate config/initializers/mongory.rb with appropriate snippets
+    #   rails g mongory:install
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path('templates', __dir__)
 
+      # Generates the Mongory initializer under `config/initializers/mongory.rb`.
+      # Dynamically injects converter and registration config based on detected ORMs.
+      #
+      # @return [void]
       def create_initializer_file
         @use_ar       = gem_used?('activerecord')
         @use_mongoid  = gem_used?('mongoid')
@@ -19,6 +30,10 @@ module Mongory
 
       private
 
+      # Checks whether a specific gem is listed in the locked dependencies.
+      #
+      # @param gem_name [String] the name of the gem to check
+      # @return [Boolean] true if the gem is present in the lockfile
       def gem_used?(gem_name)
         Bundler.locked_gems.dependencies.key?(gem_name)
       end

--- a/lib/generators/mongory/install/templates/initializer.rb.erb
+++ b/lib/generators/mongory/install/templates/initializer.rb.erb
@@ -63,10 +63,6 @@ Mongory.configure do |mc|
       # You may register condition key converters here.
       # Example:
       # kc.register(MyKeyObject, :trans_to_string_key_pair)
-      <% if @use_mongoid %>
-      # It's Mongoid built-in key operator that born from `:key.gt`
-      kc.register(Mongoid::Criteria::Queryable::Key, :__expr_part__)
-      <% end %>
     end
 
     cc.value_converter.configure do |vc|

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -13,59 +13,18 @@ require_relative 'mongory/rails' if defined?(Rails::Railtie)
 
 # Main namespace for Mongory DSL and configuration.
 #
-# This module exposes the top-level API for building queries
-# and accessing core components like converters and debugger.
+# Provides access to core converters, query construction, and optional
+# integrations with frameworks like Rails or Mongoid.
+#
+# @example Basic usage
+#   Mongory.build_query(records).where(age: { :$gt => 18 })
+#
+# @example Enabling DSL snippets
+#   Mongory.enable_symbol_snippets!
+#   Mongory.register(Array)
 module Mongory
-  # Creates a new query builder for the given records.
-  #
-  # @param records [Enumerable] any collection of data
-  # @return [QueryBuilder]
-  def self.build_query(records)
-    QueryBuilder.new(records)
-  end
-
-  # Yields Mongory for configuration and freezes key components.
-  #
-  # @example Configure converters
-  #   Mongory.configure do |mc|
-  #     mc.data_converter.configure do |dc|
-  #       dc.register(MyType) { transform(self) }
-  #     end
-  #
-  #     mc.condition_converter.key_converter.configure do |kc|
-  #       kc.register(MyKeyType) { normalize_key(self) }
-  #     end
-  #
-  #     mc.condition_converter.value_converter.configure do |vc|
-  #       vc.register(MyValueType) { cast_value(self) }
-  #     end
-  #   end
-  #
-  # @yieldparam self [Mongory]
-  # @return [void]
-  def self.configure
-    yield self
-    data_converter.freeze
-    condition_converter.freeze
-  end
-
-  # @params klass [Class] the class that you want to add `#mongory` method.
-  # @return [void]
-  def self.register(klass)
-    klass.include(ClassExtention)
-  end
-  # Implement Symbol snippets like `:name.regex`
-
-  # @return [void]
-  def self.enable_symbol_snippets!
-    Mongory::QueryOperator::METHOD_TO_OPERATOR_MAPPING.each do |key, operator|
-      next if ::Symbol.method_defined?(key)
-
-      ::Symbol.define_method(key) do
-        Mongory::QueryOperator.new(to_s, operator)
-      end
-    end
-  end
+  class Error < StandardError; end
+  class TypeError < Error; end
 
   # Returns the data converter instance.
   #
@@ -81,19 +40,53 @@ module Mongory
     Converters::ConditionConverter
   end
 
-  # Returns the debugger controller.
+  # Returns the debugger instance.
   #
   # @return [Utils::Debugger]
   def self.debugger
     Utils::Debugger
   end
 
-  # Base class for all Mongory errors.
-  class Error < StandardError; end
-  class TypeError < Error; end
+  # Builds a new query over the given record set.
+  #
+  # @param records [Enumerable] any enumerable object (Array, AR::Relation, etc.)
+  # @return [QueryBuilder] a new query builder
+  def self.build_query(records)
+    QueryBuilder.new(records)
+  end
 
-  # Temp description
+  # Registers a class to support `.mongory` query DSL.
+  # This injects a `#mongory` method into the given class.
+  #
+  # @param klass [Class] the class to register (e.g., Array, ActiveRecord::Relation)
+  # @return [void]
+  def self.register(klass)
+    klass.include(ClassExtention)
+  end
+
+  # Enables symbol snippets like `:age.gte` or `:name.regex`
+  # by dynamically defining methods on `Symbol` for query operators.
+  #
+  # Skips operators that already exist to avoid patching Mongoid or other gems.
+  #
+  # @return [void]
+  def self.enable_symbol_snippets!
+    Mongory::QueryOperator::METHOD_TO_OPERATOR_MAPPING.each do |key, operator|
+      next if ::Symbol.method_defined?(key)
+
+      ::Symbol.define_method(key) do
+        Mongory::QueryOperator.new(to_s, operator)
+      end
+    end
+  end
+
+  # Adds a `#mongory` method to the target class via inclusion.
+  #
+  # Typically used internally by `Mongory.register(...)`.
   module ClassExtention
+    # Returns a query builder scoped to `self`.
+    #
+    # @return [QueryBuilder]
     def mongory
       Mongory::QueryBuilder.new(self)
     end

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -10,6 +10,7 @@ require_relative 'mongory/query_builder'
 require_relative 'mongory/query_operator'
 require_relative 'mongory/converters'
 require_relative 'mongory/rails' if defined?(Rails::Railtie)
+require_relative 'mongory/mongoid' if defined?(Mongoid)
 
 # Main namespace for Mongory DSL and configuration.
 #

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -9,6 +9,7 @@ require_relative 'mongory/query_matcher'
 require_relative 'mongory/query_builder'
 require_relative 'mongory/query_operator'
 require_relative 'mongory/converters'
+require_relative 'mongory/rails' if defined?(Rails::Railtie)
 
 # Main namespace for Mongory DSL and configuration.
 #

--- a/lib/mongory/converters/condition_converter.rb
+++ b/lib/mongory/converters/condition_converter.rb
@@ -16,7 +16,7 @@ module Mongory
       # Converts a flat condition hash into a nested structure.
       #
       # @param condition [Hash]
-      # @return [Hash] nested condition
+      # @return [Hash] the transformed nested condition
       def convert(condition)
         result = {}
         condition.each_pair do |k, v|
@@ -27,7 +27,7 @@ module Mongory
         result
       end
 
-      # Deep merge block used to merge nested hashes
+      # Provides a block that merges values for overlapping keys in a deep way.
       #
       # @return [Proc]
       def deep_merge_block
@@ -40,23 +40,23 @@ module Mongory
         end
       end
 
-      # Returns the key converter
+      # Returns the key converter used to transform condition keys.
       #
       # @return [ConverterBuilder]
       def key_converter
         KeyConverter
       end
 
-      # Returns the value converter
+      # Returns the value converter used to transform condition values.
       #
       # @return [ConverterBuilder]
       def value_converter
         ValueConverter
       end
 
-      # Prepares and freezes all internal components
+      # Freezes internal converters to prevent further modification.
       #
-      # @return [ConditionConverter]
+      # @return [void]
       def freeze
         deep_merge_block
         super

--- a/lib/mongory/converters/converter_builder.rb
+++ b/lib/mongory/converters/converter_builder.rb
@@ -22,7 +22,10 @@ module Mongory
       # @private
       NOTHING = SingletonBuilder.new('NOTHING')
 
-      # @param block [Proc] optional DSL configuration block
+      # Initializes the builder with a label and optional configuration block.
+      #
+      # @param label [String] a name for the converter
+      # @yield [block] optional configuration block
       def initialize(label, &block)
         @registries = []
         @fallback = Proc.new { |*| self }
@@ -32,8 +35,8 @@ module Mongory
       # Applies the registered conversion to the given target object.
       #
       # @param target [Object] the object to convert
-      # @param other [Object] optional secondary argument
-      # @return [Object] the result of the conversion
+      # @param other [Object] optional secondary value
+      # @return [Object] converted result
       def convert(target, other = NOTHING)
         @registries.each do |registry|
           next unless target.is_a?(registry.klass)
@@ -44,11 +47,11 @@ module Mongory
         exec_convert(target, other, &@fallback)
       end
 
-      # Executes the conversion block with the appropriate arguments.
+      # Internal dispatch logic to apply a matching converter.
       #
-      # @param target [Object]
-      # @param other [Object]
-      # @yield the conversion block
+      # @param target [Object] the object to match
+      # @param other [Object] optional extra data
+      # @yield fallback block if no converter is found
       # @return [Object]
       def exec_convert(target, other, &block)
         if other == NOTHING
@@ -58,18 +61,18 @@ module Mongory
         end
       end
 
-      # Yields self to a block for configuration, then freezes the builder.
+      # Opens a configuration block to register more converters.
       #
-      # @yield [ConverterBuilder]
-      # @return [ConverterBuilder] the frozen builder
+      # @yield DSL block to configure more rules
+      # @return [void]
       def configure
         yield self
         freeze
       end
 
-      # Freezes internal registry state as well.
+      # Freezes all internal registries.
       #
-      # @return [ConverterBuilder]
+      # @return [void]
       def freeze
         super
         @registries.freeze

--- a/lib/mongory/matchers.rb
+++ b/lib/mongory/matchers.rb
@@ -25,6 +25,10 @@ require_relative 'matchers/present_matcher'
 require_relative 'matchers/regex_matcher'
 
 module Mongory
+  # Defines built-in Mongory matchers for query condition evaluation.
+  #
+  # This file loads and registers all available matcher classes
+  # and maps Mongo-style operators (e.g., `$gt`, `$in`) to matcher implementations.
   # Matcher lookup and operator dispatch mapping.
   #
   # This module contains the `$operator => MatcherClass` mapping used

--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -3,10 +3,12 @@
 module Mongory
   module Matchers
     # AbstractMatcher is the base class for all matchers in Mongory.
+    #
     # It defines a common interface (`#match?`) and provides shared behavior
     # such as condition storage, optional conversion handling, and debugging output.
     #
     # Subclasses are expected to implement `#match(record)` to define their matching logic.
+    #
     # This class also supports caching of lazily-built matchers via `define_matcher`.
     #
     # @abstract
@@ -29,7 +31,7 @@ module Mongory
       # @return [Object] the raw condition this matcher was initialized with
       attr_reader :condition
 
-      # Initializes the matcher with a condition and optional conversion control.
+      # Initializes the matcher with a raw condition.
       #
       # @param condition [Object] the condition to match against
       def initialize(condition)
@@ -45,10 +47,10 @@ module Mongory
       # @return [Boolean] whether the record matches the condition
       def match(*); end
 
-      # Wrapper for `#match` with clearer semantics.
+      # Matches the given record against the condition.
       #
-      # @param record [Object] the input record to test
-      # @return [Boolean] whether the record matches the condition
+      # @param record [Object] the input record
+      # @return [Boolean]
       def match?(record)
         match(record)
       end
@@ -73,17 +75,20 @@ module Mongory
         Debugger.indent_level -= 1
       end
 
-      private
-
-      # Hook for subclasses to validate the given condition.
-      # Default is no-op. Should raise if condition is malformed.
+      # Validates the condition (no-op by default).
+      # Override in subclasses to raise error if invalid.
       #
       # @return [void]
       def check_validity!; end
 
+      # Recursively checks validity (calls `check_validity!`).
+      #
+      # @return [void]
       def deep_check_validity!
         check_validity!
       end
+
+      private
 
       # Normalizes a potentially missing record value.
       # Converts sentinel `KEY_NOT_FOUND` to nil.

--- a/lib/mongory/matchers/abstract_multi_matcher.rb
+++ b/lib/mongory/matchers/abstract_multi_matcher.rb
@@ -16,13 +16,19 @@ module Mongory
     # @abstract
     # @see AbstractMatcher
     class AbstractMultiMatcher < AbstractMatcher
-      # Performs matching over all sub-matchers using the specified operator.
-      # The input record may be preprocessed first (e.g., for normalization).
+      # Enables auto-dispatch logic.
+      # When used, `.build` may unwrap to first matcher if only one is present.
+      #
+      # @return [void]
       def self.dispatch!
         @dispatch = true
         singleton_class.alias_method :build, :dispatch
       end
 
+      # Builds a matcher and conditionally unwraps it.
+      #
+      # @param args [Array] arguments passed to the constructor
+      # @return [AbstractMatcher]
       def self.dispatch(*args)
         matcher = new(*args)
         return matcher unless @dispatch
@@ -31,6 +37,9 @@ module Mongory
         matcher
       end
 
+      # Performs matching over all sub-matchers using the specified operator.
+      # The input record may be preprocessed first (e.g., for normalization).
+      #
       # @param record [Object] the record to match
       # @return [Boolean] whether the combined result of sub-matchers satisfies the condition
       def match(record)
@@ -70,6 +79,9 @@ module Mongory
       # @return [Symbol] the operator method to apply over matchers
       def operator; end
 
+      # Recursively checks all submatchers for validity.
+      #
+      # @return [void]
       def deep_check_validity!
         super
         matchers.each(&:deep_check_validity!)

--- a/lib/mongory/matchers/and_matcher.rb
+++ b/lib/mongory/matchers/and_matcher.rb
@@ -3,7 +3,9 @@
 module Mongory
   module Matchers
     # AndMatcher implements the `$and` logical operator.
+    #
     # It receives an array of subconditions and matches only if *all* of them succeed.
+    #
     # Each subcondition is dispatched through a ConditionMatcher, with conversion disabled
     # to avoid redundant processing.
     #
@@ -23,24 +25,24 @@ module Mongory
       # Conversion is disabled to avoid double-processing.
       dispatch!
 
-      # @see ConditionMatcher
-      # @param condition [Object] the raw subcondition
-      # @return [ConditionMatcher] the matcher instance for the condition
+      # Builds a matcher for each subcondition using ConditionMatcher.
+      #
+      # @param condition [Hash] subcondition hash
+      # @return [AbstractMatcher]
       def build_sub_matcher(condition)
         ConditionMatcher.build(condition)
       end
 
-      # Uses the `:all?` operator to ensure all subconditions must match.
+      # Combines submatcher results using `:all?`.
       #
-      # @return [Symbol] the combining operator
+      # @return [Symbol]
       def operator
         :all?
       end
 
-      # Validates that the condition is an Array.
-      # Raises a TypeError if the input is malformed.
+      # Ensures the condition is an array of hashes.
       #
-      # @raise [TypeError] if condition is not an Array
+      # @raise [Mongory::TypeError] if not valid
       # @return [void]
       def check_validity!
         raise TypeError, '$and needs an array' unless @condition.is_a?(Array)

--- a/lib/mongory/matchers/collection_matcher.rb
+++ b/lib/mongory/matchers/collection_matcher.rb
@@ -7,6 +7,7 @@ module Mongory
     # more complex nested logic using an `ElemMatchMatcher`.
     #
     # If the condition is not a Hash, it falls back to simple inclusion check (`Array#include?`).
+    #
     # If the condition is a Hash, each key/value is used to build an appropriate matcher.
     #
     # Submatchers are built dynamically depending on whether the key is an integer index,
@@ -18,15 +19,19 @@ module Mongory
     #
     # @see AbstractMultiMatcher
     class CollectionMatcher < AbstractMultiMatcher
-      # Custom matching logic: if condition is not a hash, do inclusion check.
-      # Otherwise, fallback to the parent AbstractMultiMatcher#match logic.
+      # Initializes the collection matcher with a condition.
+      #
+      # @param condition [Object] the condition to match
       def initialize(condition, *)
         @condition_is_hash = condition.is_a?(Hash)
         super
       end
 
-      # @param collection [Object] the collection to be tested (usually an Array)
-      # @return [Boolean] whether the condition matches the collection
+      # Matches the input collection.
+      # Falls back to include? check unless condition is a Hash.
+      #
+      # @param collection [Object]
+      # @return [Boolean]
       def match(collection)
         return super if @condition_is_hash
 
@@ -67,13 +72,16 @@ module Mongory
         end
       end
 
-      # Uses `:all?` to ensure all sub-matchers must match.
+      # Combines results using `:all?` for multi-match logic.
       #
-      # @return [Symbol] the combining operator
+      # @return [Symbol]
       def operator
         :all?
       end
 
+      # Performs recursive validity checks on nested matchers if condition is a Hash.
+      #
+      # @return [void]
       def deep_check_validity!
         super if @condition_is_hash
       end

--- a/lib/mongory/matchers/condition_matcher.rb
+++ b/lib/mongory/matchers/condition_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # ConditionMatcher is responsible for handling field-level query conditions.
+    #
     # It receives a Hash of key-value pairs and delegates each one to an appropriate matcher
     # based on whether the key is a recognized operator or a data field path.
     #
@@ -18,10 +19,10 @@ module Mongory
     #
     # @see AbstractMultiMatcher
     class ConditionMatcher < AbstractMultiMatcher
+      dispatch!
       # Constructs the appropriate submatcher for a key-value pair.
       # If the key is a registered operator, dispatches to the corresponding matcher.
       # Otherwise, assumes the key is a field path and uses DigValueMatcher.
-      dispatch!
 
       # @see DigValueMatcher
       # @see Matchers.lookup

--- a/lib/mongory/matchers/default_matcher.rb
+++ b/lib/mongory/matchers/default_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # DefaultMatcher is the main entry point of Mongory's matcher pipeline.
+    #
     # It delegates matching to more specific matchers depending on the shape
     # of the given condition and record.
     #
@@ -11,9 +12,6 @@ module Mongory
     #   - If the record is an Array, delegate to CollectionMatcher.
     #   - If the condition is a Hash, delegate to ConditionMatcher.
     #   - Otherwise, return false.
-    #
-
-    #
     # @example
     #   matcher = DefaultMatcher.build({ age: { :$gte => 30 } })
     #   matcher.match(record) #=> true or false
@@ -22,11 +20,14 @@ module Mongory
     class DefaultMatcher < AbstractMatcher
       # Matches the given record against the stored condition.
       # The logic dynamically chooses the appropriate sub-matcher.
+      # @param condition [Object] the raw condition
       def initialize(condition, *)
         @condition_is_hash = condition.is_a?(Hash)
         super
       end
 
+      # Matches the given record against the condition.
+      #
       # @param record [Object] the record to be matched
       # @return [Boolean] whether the record satisfies the condition
       def match(record)
@@ -60,6 +61,9 @@ module Mongory
         ConditionMatcher.build(@condition)
       end
 
+      # Validates the nested condition matcher, if applicable.
+      #
+      # @return [void]
       def deep_check_validity!
         condition_matcher.deep_check_validity! if @condition_is_hash
       end

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -29,6 +29,8 @@ module Mongory
         ::Symbol
       ].freeze
 
+      # Initializes the matcher with a target key and condition.
+      #
       # @param key [Object] the key (or index) used to dig into the record
       # @param condition [Object] the condition to match against the extracted value
       def initialize(key, condition)
@@ -36,7 +38,7 @@ module Mongory
         super(condition)
       end
 
-      # Extracts the target value using the key and delegates to DefaultMatcher.
+      # Matches the record by extracting the value via key and applying the condition.
       #
       # @param record [Object] the record to match
       # @return [Boolean] whether the extracted value matches the condition

--- a/lib/mongory/matchers/elem_match_matcher.rb
+++ b/lib/mongory/matchers/elem_match_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # ElemMatchMatcher implements the logic for Mongo-style `$elemMatch`.
+    #
     # It is used to determine if *any* element in an array matches the given condition.
     #
     # This matcher delegates element-wise comparison to ConditionMatcher,
@@ -30,6 +31,10 @@ module Mongory
         end
       end
 
+      # Ensures the condition is a Hash.
+      #
+      # @raise [Mongory::TypeError] if the condition is not a Hash
+      # @return [void]
       def check_validity!
         raise TypeError, '$elemMatch needs a Hash.' unless @condition.is_a?(Hash)
       end

--- a/lib/mongory/matchers/eq_matcher.rb
+++ b/lib/mongory/matchers/eq_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # EqMatcher matches values using the equality operator `==`.
+    #
     # It inherits from AbstractOperatorMatcher and defines its operator as `:==`.
     #
     # Used for conditions like:

--- a/lib/mongory/matchers/every_matcher.rb
+++ b/lib/mongory/matchers/every_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # EveryMatcher implements the logic for Mongo-style `$every` which is not really support in MongoDB.
+    #
     # It is used to determine if *all* element in an array matches the given condition.
     #
     # This matcher delegates element-wise comparison to ConditionMatcher,

--- a/lib/mongory/matchers/gt_matcher.rb
+++ b/lib/mongory/matchers/gt_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # GtMatcher implements the `$gt` (greater than) operator.
+    #
     # It returns true if the record is strictly greater than the condition.
     #
     # Inherits core logic from AbstractOperatorMatcher, including

--- a/lib/mongory/matchers/gte_matcher.rb
+++ b/lib/mongory/matchers/gte_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # GteMatcher implements the `$gte` (greater than or equal) operator.
+    #
     # It returns true if the record is greater than or equal to the condition value.
     #
     # Inherits comparison logic and error safety from AbstractOperatorMatcher.

--- a/lib/mongory/matchers/in_matcher.rb
+++ b/lib/mongory/matchers/in_matcher.rb
@@ -23,7 +23,7 @@ module Mongory
       # @param record [Object] the record value to test
       # @return [Boolean] whether any values intersect
       def match(record)
-        present?(@condition & Array(record))
+        is_present?(@condition & Array(record))
       end
 
       # Ensures the condition is an array.

--- a/lib/mongory/matchers/in_matcher.rb
+++ b/lib/mongory/matchers/in_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # InMatcher implements the `$in` operator.
+    #
     # It checks whether the record (converted to an array) has any overlap
     # with the condition array. This supports both scalar and array inputs.
     #

--- a/lib/mongory/matchers/lt_matcher.rb
+++ b/lib/mongory/matchers/lt_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # LtMatcher implements the `$lt` (less than) operator.
+    #
     # It returns true if the record is strictly less than the condition value.
     #
     # This matcher inherits from AbstractOperatorMatcher and uses the `<` operator.

--- a/lib/mongory/matchers/lte_matcher.rb
+++ b/lib/mongory/matchers/lte_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # LteMatcher implements the `$lte` (less than or equal to) operator.
+    #
     # It returns true if the record is less than or equal to the condition value.
     #
     # This matcher inherits from AbstractOperatorMatcher and uses the `<=` operator.

--- a/lib/mongory/matchers/ne_matcher.rb
+++ b/lib/mongory/matchers/ne_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # NeMatcher implements the `$ne` (not equal) operator.
+    #
     # It returns true if the record is *not equal* to the condition.
     #
     # This matcher inherits its logic from AbstractOperatorMatcher

--- a/lib/mongory/matchers/nin_matcher.rb
+++ b/lib/mongory/matchers/nin_matcher.rb
@@ -3,7 +3,9 @@
 module Mongory
   module Matchers
     # NinMatcher implements the `$nin` (not in) operator.
+    #
     # It returns true if *none* of the record's values appear in the condition array.
+    #
     # The record is cast to an array to ensure uniform behavior across types.
     #
     # This matcher is the logical opposite of InMatcher.

--- a/lib/mongory/matchers/nin_matcher.rb
+++ b/lib/mongory/matchers/nin_matcher.rb
@@ -22,7 +22,7 @@ module Mongory
       # @param record [Object] the value to be tested
       # @return [Boolean] whether the record is disjoint from the condition array
       def match(record)
-        blank?(@condition & Array(record))
+        is_blank?(@condition & Array(record))
       end
 
       # Ensures the condition is a valid array.

--- a/lib/mongory/matchers/not_matcher.rb
+++ b/lib/mongory/matchers/not_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # NotMatcher implements the `$not` logical operator.
+    #
     # It returns true if the wrapped matcher fails, effectively inverting the result.
     #
     # It delegates to DefaultMatcher and simply negates the outcome.

--- a/lib/mongory/matchers/or_matcher.rb
+++ b/lib/mongory/matchers/or_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # OrMatcher implements the `$or` logical operator.
+    #
     # It evaluates an array of subconditions and returns true
     # if *any one* of them matches.
     #
@@ -21,9 +22,9 @@ module Mongory
     #
     # @see AbstractMultiMatcher
     class OrMatcher < AbstractMultiMatcher
+      dispatch!
       # Constructs a ConditionMatcher for each subcondition.
       # Conversion is disabled to avoid double-processing.
-      dispatch!
 
       # @see ConditionMatcher
       # @param condition [Object] a subcondition to be wrapped
@@ -39,9 +40,9 @@ module Mongory
         :any?
       end
 
-      # Ensures the condition is an array of subconditions.
+      # Ensures the condition is an array of hashes.
       #
-      # @raise [TypeError] if condition is not an array
+      # @raise [Mongory::TypeError] if not valid
       # @return [void]
       def check_validity!
         raise TypeError, '$or needs an array' unless @condition.is_a?(Array)

--- a/lib/mongory/matchers/present_matcher.rb
+++ b/lib/mongory/matchers/present_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # PresentMatcher implements the `$present` operator.
+    #
     # It returns true if the record value is considered "present"
     # (i.e., not nil, not empty, not KEY_NOT_FOUND), and matches
     # the expected boolean condition.

--- a/lib/mongory/matchers/present_matcher.rb
+++ b/lib/mongory/matchers/present_matcher.rb
@@ -27,7 +27,7 @@ module Mongory
       # @param record [Object] the original value
       # @return [Boolean] whether the value is present
       def preprocess(record)
-        present?(super)
+        is_present?(super)
       end
 
       # Uses Ruby `==` to compare the presence result to the expected boolean.

--- a/lib/mongory/matchers/regex_matcher.rb
+++ b/lib/mongory/matchers/regex_matcher.rb
@@ -3,6 +3,7 @@
 module Mongory
   module Matchers
     # RegexMatcher implements the `$regex` operator.
+    #
     # It returns true if the record string matches the given pattern string.
     #
     # Although `@condition` is passed as a string (due to ValueConverter converting

--- a/lib/mongory/mongoid.rb
+++ b/lib/mongory/mongoid.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# .
+module Mongory
+  # Only loaded when Mongoid is present
+  module MongoidPatch
+    # Regist Mongoid operator key object into KeyConverter
+    # @see Converters::KeyConverter
+    # @return [void]
+    def self.patch!
+      kc = Mongory.condition_converter.key_converter
+      # It's Mongoid built-in key operator that born from `:key.gt`
+      kc.register(::Mongoid::Criteria::Queryable::Key) do |v|
+        kc.convert(@name.to_s, @operator => v)
+      end
+    end
+  end
+
+  MongoidPatch.patch!
+end

--- a/lib/mongory/query_builder.rb
+++ b/lib/mongory/query_builder.rb
@@ -7,6 +7,7 @@ module Mongory
   #
   # It supports condition chaining (`where`, `or`, `not`),
   # sorting (`asc`, `desc`), limiting, and plucking fields.
+  #
   # Internally it compiles all conditions and invokes `QueryMatcher`.
   #
   # @example

--- a/lib/mongory/query_operator.rb
+++ b/lib/mongory/query_operator.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module Mongory
-  # Temp Description
+  # Wrapper for symbol-based operator expressions.
+  #
+  # Used to support DSL like `:age.gt => 18` where `gt` maps to `$gt`.
+  # Converts into: `{ "age" => { "$gt" => 18 } }`
   class QueryOperator
     METHOD_TO_OPERATOR_MAPPING = {
       eq: '$eq',
@@ -22,11 +25,21 @@ module Mongory
       every: '$every'
     }.freeze
 
+    # Initializes a new query operator wrapper.
+    #
+    # @param name [String] the original field name
+    # @param operator [String] the Mongo-style operator (e.g., '$gt')
     def initialize(name, operator)
       @name = name
       @operator = operator
     end
 
+    # Converts the operator and value into a condition hash.
+    #
+    # Typically called by the key converter.
+    #
+    # @param other [Object] the value to match against
+    # @return [Hash] converted query condition
     def __expr_part__(other, *)
       Converters::KeyConverter.convert(@name, @operator => other)
     end

--- a/lib/mongory/rails.rb
+++ b/lib/mongory/rails.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails'
+require_relative 'utils/rails_patch'
+
+module Mongory
+  # Temp description
+  class Railtie < Rails::Railtie
+    initializer 'mongory.patch_utils' do
+      Mongory::Utils.prepend(Mongory::Utils::RailsPatch)
+    end
+  end
+end

--- a/lib/mongory/rails.rb
+++ b/lib/mongory/rails.rb
@@ -4,7 +4,7 @@ require 'rails'
 require_relative 'utils/rails_patch'
 
 module Mongory
-  # Temp description
+  # @see Utils::RailsPatch
   class Railtie < Rails::Railtie
     initializer 'mongory.patch_utils' do
       Mongory::Utils.prepend(Mongory::Utils::RailsPatch)

--- a/lib/mongory/utils.rb
+++ b/lib/mongory/utils.rb
@@ -19,12 +19,12 @@ module Mongory
     end
 
     # Checks if an object is "present".
-    # Inverse of {#blank?}.
+    # Inverse of {#is_blank?}.
     #
     # @param obj [Object]
     # @return [Boolean]
-    def present?(obj)
-      !blank?(obj)
+    def is_present?(obj)
+      !is_blank?(obj)
     end
 
     # Determines whether an object is considered "blank".
@@ -32,7 +32,7 @@ module Mongory
     #
     # @param obj [Object]
     # @return [Boolean]
-    def blank?(obj)
+    def is_blank?(obj)
       case obj
       when false, nil
         true

--- a/lib/mongory/utils/rails_patch.rb
+++ b/lib/mongory/utils/rails_patch.rb
@@ -4,10 +4,16 @@ module Mongory
   module Utils
     # Only loaded when Rails is present
     module RailsPatch
+      # Use Object#present? which defined in Rails.
+      # @param target[Object]
+      # @return [Boolean]
       def is_present?(target)
         target.present?
       end
 
+      # Use Object#blank? which defined in Rails.
+      # @param target[Object]
+      # @return [Boolean]
       def is_blank?(target)
         target.blank?
       end

--- a/lib/mongory/utils/rails_patch.rb
+++ b/lib/mongory/utils/rails_patch.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Mongory
+  module Utils
+    # Only loaded when Rails is present
+    module RailsPatch
+      def is_present?(target)
+        target.present?
+      end
+
+      def is_blank?(target)
+        target.blank?
+      end
+    end
+  end
+end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.5.0'
+  VERSION = '1.6.0'
 end


### PR DESCRIPTION
🎉 Mongory v1.6.1 – Rails & Mongoid Integration

This release brings full Rails and Mongoid integration, making Mongory easier to use across common Ruby web frameworks.

### ✨ Added
- **Rails auto-integration** via `Railtie`, includes runtime patch for `.present?` / `.blank?`
- **Mongoid extension** to support symbolic operator keys (`:age.gt`) via internal key converter registration
- **Auto require** support for `rails` and `mongoid` integration modules when constants are detected
- **YARD docs** for all public APIs and generators

### 🛠 Changed
- **Initializer generator** now cleaner – no more inline Mongoid logic, all moved to `mongory/mongoid`
- **Symbol snippets** are fully opt-in and safely isolated

This release finalizes the architecture for safe DSL usage in Rails/Mongoid projects. Recommended for all Rails users.
