### PR TITLE
Release/1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.6.4] - 2025-04-11
+
+### Fixed
+
+- `MongoidPatch` now references `Mongory::Converters::KeyConverter` directly instead of lazily accessing it through `.condition_converter`.
+- Restored missing `Mongory.configure` method accidentally removed in earlier documentation refactor.
+- Ensured all `.configure` entrypoints are consistently available for all converters.
+
 ## [1.6.1] - 2025-04-11
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.6.3)
+    mongory (1.6.4)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.6.2)
+    mongory (1.6.3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.6.1)
+    mongory (1.6.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/generators/mongory/install/templates/initializer.rb.erb
+++ b/lib/generators/mongory/install/templates/initializer.rb.erb
@@ -32,30 +32,30 @@ Mongory.configure do |mc|
   # Here to let you use `some_collection.mongory.where(...)` to build mongory query filter.
   # Or disable it, and use `Mongory.build_query(some_collection).where(...)` instead.
   mc.register(Array)
-  <% if @use_ar %>
+<% if @use_ar -%>
   mc.register(ActiveRecord::Relation)
-  <% end %>
-  <% if @use_mongoid %>
+<% end -%>
+<% if @use_mongoid -%>
   mc.register(Mongoid::Criteria)
-  <% end %>
-  <% if @use_sequel %>
+<% end -%>
+<% if @use_sequel -%>
   mc.register(Sequel::Dataset)
-  <% end %>
+<% end -%>
 
   mc.data_converter.configure do |dc|
     # Here to let you customize how to normalizing your ORM object or custom class into comparable format.
     # Example:
     # dc.register(ActiveRecord::Base, :attributes)
-    <% if @use_ar %>
+<% if @use_ar -%>
     dc.register(ActiveRecord::Base, :attributes)
-    <% end %>
-    <% if @use_mongoid %>
+<% end -%>
+<% if @use_mongoid -%>
     dc.register(Mongoid::Document, :as_document)
     dc.register(BSON::ObjectId, :to_s)
-    <% end %>
-    <% if @use_sequel %>
+<% end -%>
+<% if @use_sequel -%>
     dc.register(Sequel::Model) { values.transform_keys(&:to_s) }
-    <% end %>
+<% end -%>
   end
 
   mc.condition_converter.configure do |cc|
@@ -69,9 +69,9 @@ Mongory.configure do |mc|
       # You may register condition value converters here.
       # Example:
       # vc.register(MyCollectionType) { map { |v| vc.convert(v) } }
-      <% if @use_mongoid %>
+<% if @use_mongoid -%>
       vc.register(BSON::ObjectId, :to_s)
-      <% end %>
+<% end -%>
     end
   end
 end

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -27,6 +27,31 @@ module Mongory
   class Error < StandardError; end
   class TypeError < Error; end
 
+  # Yields Mongory for configuration and freezes key components.
+  #
+  # @example Configure converters
+  #   Mongory.configure do |mc|
+  #     mc.data_converter.configure do |dc|
+  #       dc.register(MyType) { transform(self) }
+  #     end
+  #
+  #     mc.condition_converter.key_converter.configure do |kc|
+  #       kc.register(MyKeyType) { normalize_key(self) }
+  #     end
+  #
+  #     mc.condition_converter.value_converter.configure do |vc|
+  #       vc.register(MyValueType) { cast_value(self) }
+  #     end
+  #   end
+  #
+  # @yieldparam self [Mongory]
+  # @return [void]
+  def self.configure
+    yield self
+    data_converter.freeze
+    condition_converter.freeze
+  end
+
   # Returns the data converter instance.
   #
   # @return [Converters::DataConverter]

--- a/lib/mongory/converters/condition_converter.rb
+++ b/lib/mongory/converters/condition_converter.rb
@@ -27,6 +27,15 @@ module Mongory
         result
       end
 
+      # Opens a configuration block to register more converters.
+      #
+      # @yield DSL block to configure more rules
+      # @return [void]
+      def configure
+        yield self
+        freeze
+      end
+
       # Provides a block that merges values for overlapping keys in a deep way.
       #
       # @return [Proc]

--- a/lib/mongory/mongoid.rb
+++ b/lib/mongory/mongoid.rb
@@ -8,7 +8,7 @@ module Mongory
     # @see Converters::KeyConverter
     # @return [void]
     def self.patch!
-      kc = Mongory.condition_converter.key_converter
+      kc = Mongory::Converters::KeyConverter
       # It's Mongoid built-in key operator that born from `:key.gt`
       kc.register(::Mongoid::Criteria::Queryable::Key) do |v|
         kc.convert(@name.to_s, @operator => v)

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.6.2'
+  VERSION = '1.6.3'
 end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.6.3'
+  VERSION = '1.6.4'
 end


### PR DESCRIPTION
🎯 Mongory v1.6.4 – Configuration Fixes & Mongoid Patch Stability

This release includes critical fixes and restorations following the `1.6.1` release.

### 🛠 Fixed

- `MongoidPatch` now references `Mongory::Converters::KeyConverter` directly instead of lazily accessing it through `.condition_converter`.
- Restored missing `Mongory.configure` method accidentally removed in earlier documentation refactor.
- Ensured all `.configure` entrypoints are consistently available for all converters, enabling clean DSL configuration.

This update is safe to upgrade and recommended for all projects using `Mongory.configure` or Mongoid.