### PR TITLE
Release/1.7.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,8 +15,9 @@ Layout/LineLength:
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    default: '[]'
+    default: '()'
     '%i':    '()'
+    '%w':    '()'
 
 Metrics/ClassLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [1.7.0] - 2025-04-13
+
+### Added
+
+- `QueryBuilder#explain` prints a tree-structured matcher breakdown using `PP`, useful for debugging.
+- Matchers now support `#render_tree` and `#tree_title`, enabling structured introspection.
+- `QueryBuilder#any_of` added as a semantic alias for `.and('$or' => [...])`.
+
+### Changed
+
+- Filter logic restructured to use immediately-parsed matchers (`set_matcher`) instead of building on `result`.
+- `.each` now directly filters via matcher tree evaluation, removing dependency on an internal condition hash.
+- Removed legacy `.result` method.
+- `.or(...)` now wraps existing conditions intelligently when merging mixed operator states.
+- `.pluck` and `.sort_by_keys` no longer convert keys to strings, fixing inconsistency with native Mongoid behavior.
+
+### Deprecated
+
+- `.asc` and `.desc` now emit deprecation warnings; they will be removed in v2.0.0.
+
 ## [1.6.4] - 2025-04-11
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (1.6.4)
+    mongory (1.7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -2,6 +2,7 @@
 
 require 'time'
 require 'date'
+require 'pp'
 require_relative 'mongory/version'
 require_relative 'mongory/utils'
 require_relative 'mongory/matchers'

--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -31,6 +31,10 @@ module Mongory
       # @return [Object] the raw condition this matcher was initialized with
       attr_reader :condition
 
+      # @return [Object] a unique key representing this matcher instance, used for deduplication
+      # @see AbstractMultiMatcher#matchers
+      alias_method :uniq_key, :condition
+
       # Initializes the matcher with a raw condition.
       #
       # @param condition [Object] the condition to match against

--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -88,7 +88,27 @@ module Mongory
         check_validity!
       end
 
+      # Recursively prints the matcher structure into a formatted tree.
+      # Supports indentation and branching layout using prefix symbols.
+      #
+      # @param pp [PP] the pretty-printer instance
+      # @param prefix [String] tree prefix (indentation + lines)
+      # @param is_last [Boolean] whether this node is the last among siblings
+      # @return [void]
+      def render_tree(pp, prefix = '', is_last: true)
+        pp.text("#{prefix}#{is_last ? '└─ ' : '├─ '}#{tree_title}\n")
+      end
+
       private
+
+      # Returns a single-line string representing this matcher in the tree output.
+      # Format: `<MatcherType>: <condition.inspect>`
+      #
+      # @return [String]
+      def tree_title
+        matcher_name = self.class.name.split('::').last.sub('Matcher', '')
+        "#{matcher_name}: #{@condition.inspect}"
+      end
 
       # Normalizes a potentially missing record value.
       # Converts sentinel `KEY_NOT_FOUND` to nil.

--- a/lib/mongory/matchers/abstract_multi_matcher.rb
+++ b/lib/mongory/matchers/abstract_multi_matcher.rb
@@ -51,11 +51,11 @@ module Mongory
 
       # Lazily builds and caches the array of sub-matchers.
       # Subclasses provide the implementation of `#build_sub_matcher`.
-      # Duplicate matchers (by condition) are removed to avoid redundancy.
+      # Duplicate matchers (by uniq_key) are removed to avoid redundancy.
       #
       # @return [Array<AbstractMatcher>] list of sub-matchers
       define_instance_cache_method(:matchers) do
-        @condition.map(&method(:build_sub_matcher)).uniq(&:condition)
+        @condition.map(&method(:build_sub_matcher)).uniq(&:uniq_key)
       end
 
       # Optional hook for subclasses to transform the input record before matching.

--- a/lib/mongory/matchers/abstract_multi_matcher.rb
+++ b/lib/mongory/matchers/abstract_multi_matcher.rb
@@ -86,6 +86,24 @@ module Mongory
         super
         matchers.each(&:deep_check_validity!)
       end
+
+      # Overrides base render_tree to recursively print all submatchers.
+      # Each child matcher will be displayed under this multi-matcher node.
+      #
+      # @param pp [PP] pretty-printer instance
+      # @param prefix [String] current line prefix for tree alignment
+      # @param is_last [Boolean] whether this node is the last sibling
+      # @return [void]
+      def render_tree(pp, prefix = '', is_last: true)
+        super
+        yield if block_given?
+
+        new_prefix = "#{prefix}#{is_last ? '   ' : '│  '}"
+        last_index = matchers.count - 1
+        matchers.each_with_index do |matcher, index|
+          matcher.render_tree(pp, new_prefix, is_last: index == last_index)
+        end
+      end
     end
   end
 end

--- a/lib/mongory/matchers/and_matcher.rb
+++ b/lib/mongory/matchers/and_matcher.rb
@@ -30,7 +30,18 @@ module Mongory
       # @param condition [Hash] subcondition hash
       # @return [AbstractMatcher]
       def build_sub_matcher(condition)
-        ConditionMatcher.build(condition)
+        ConditionMatcher.new(condition)
+      end
+
+      # Returns the list of all submatchers, recursively flattened.
+      # Deduplicates matchers using `uniq_key` to avoid redundant evaluation.
+      #
+      # @return [Array<AbstractMatcher>]
+      # @see AbstractMatcher#uniq_key
+      def matchers
+        return @matchers if defined?(@matchers)
+
+        @matchers = super.flat_map(&:matchers).uniq(&:uniq_key)
       end
 
       # Combines submatcher results using `:all?`.

--- a/lib/mongory/matchers/collection_matcher.rb
+++ b/lib/mongory/matchers/collection_matcher.rb
@@ -85,6 +85,19 @@ module Mongory
       def deep_check_validity!
         super if @condition_is_hash
       end
+
+      # Outputs the tree representation of this matcher.
+      # Can optionally yield to allow conditional delegation to submatchers.
+      #
+      # @param pp [PP]
+      # @param prefix [String]
+      # @param is_last [Boolean]
+      # @return [void]
+      def render_tree(*)
+        super do
+          return unless @condition_is_hash
+        end
+      end
     end
   end
 end

--- a/lib/mongory/matchers/default_matcher.rb
+++ b/lib/mongory/matchers/default_matcher.rb
@@ -67,6 +67,24 @@ module Mongory
       def deep_check_validity!
         condition_matcher.deep_check_validity! if @condition_is_hash
       end
+
+      # Outputs the matcher tree by selecting either collection or condition matcher.
+      # Delegates `render_tree` to whichever submatcher was active.
+      #
+      # @param pp [PP]
+      # @param prefix [String]
+      # @param is_last [Boolean]
+      # @return [void]
+      def render_tree(pp, prefix = '', is_last: true)
+        super
+
+        new_prefix = "#{prefix}#{is_last ? '   ' : '│  '}"
+        if @collection_matcher
+          @collection_matcher.render_tree(pp, new_prefix, is_last: true)
+        elsif @condition_is_hash
+          condition_matcher.render_tree(pp, new_prefix, is_last: true)
+        end
+      end
     end
   end
 end

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -46,6 +46,12 @@ module Mongory
         super(Mongory.data_converter.convert(dig_value(record)))
       end
 
+      # @return [Object] a deduplication key used for matchers inside multi-match constructs
+      # @see AbstractMultiMatcher#matchers
+      def uniq_key
+        { @key => @condition }
+      end
+
       private
 
       # Returns a single-line summary of the dig matcher including the key and condition.

--- a/lib/mongory/matchers/dig_value_matcher.rb
+++ b/lib/mongory/matchers/dig_value_matcher.rb
@@ -48,6 +48,13 @@ module Mongory
 
       private
 
+      # Returns a single-line summary of the dig matcher including the key and condition.
+      #
+      # @return [String]
+      def tree_title
+        "Dig: #{@key.inspect} to: #{@condition.inspect}"
+      end
+
       # Attempts to extract the value from the given record using @key.
       # Guards against unsupported types and returns KEY_NOT_FOUND if extraction fails.
       #

--- a/lib/mongory/query_builder.rb
+++ b/lib/mongory/query_builder.rb
@@ -142,6 +142,18 @@ module Mongory
 
     alias_method :selector, :condition
 
+    # Prints the internal matcher tree structure for the current query.
+    # Uses `PP` to output a human-readable visual tree of matchers.
+    # This is useful for debugging and visualizing complex conditions.
+    #
+    # @return [void]
+    def explain
+      @matcher.match(@records.first)
+      pp = PP.new($stdout)
+      @matcher.render_tree(pp)
+      pp.flush
+    end
+
     private
 
     # @private

--- a/lib/mongory/query_builder.rb
+++ b/lib/mongory/query_builder.rb
@@ -13,7 +13,7 @@ module Mongory
   # @example
   #   records.mongory
   #     .where(:age.gte => 18)
-  #     .or({ :name => /J/ }, { :name.eq => "Bob" })
+  #     .or({ :name => /J/ }, { :name.eq => 'Bob' })
   #     .desc(:age)
   #     .limit(2)
   #     .to_a
@@ -21,26 +21,27 @@ module Mongory
     include ::Enumerable
     include Utils
 
-    # @return [Hash] the raw compiled condition
-    attr_reader :condition
-
-    # @param records [Enumerable] the in-memory dataset to query
+    # Initializes a new query builder with the given record set.
+    #
+    # @param records [Enumerable] the collection to query against
     def initialize(records)
       @records = records
-      @condition = Hash.new { |h, k| h[k] = [] }
+      set_matcher
     end
 
-    # Enumerates over filtered result set.
+    # Iterates through all records that match the current matcher.
     #
-    # @yieldparam record [Object] an item from the original enumerable
-    # @return [Enumerator, void]
-    def each(&block)
+    # @yieldparam record [Object]
+    # @return [Enumerator]
+    def each
       return to_enum(:each) unless block_given?
 
-      result.each(&block)
+      @records.each do |record|
+        yield record if @matcher.match?(record)
+      end
     end
 
-    # Adds a condition using `$and`.
+    # Adds a condition to filter records using the given condition.
     #
     # @param condition [Hash]
     # @return [QueryBuilder] a new builder instance
@@ -48,27 +49,7 @@ module Mongory
       self.and(condition)
     end
 
-    # Adds multiple `$and` conditions.
-    #
-    # @param conditions [Array<Hash>]
-    # @return [QueryBuilder]
-    def and(*conditions)
-      dup_instance_exec do
-        @condition['$and'] += conditions
-      end
-    end
-
-    # Adds multiple `$or` conditions.
-    #
-    # @param conditions [Array<Hash>]
-    # @return [QueryBuilder]
-    def or(*conditions)
-      dup_instance_exec do
-        @condition['$or'] += conditions
-      end
-    end
-
-    # Adds a `$not` wrapper to a condition.
+    # Adds a negated condition to the current query.
     #
     # @param condition [Hash]
     # @return [QueryBuilder]
@@ -76,63 +57,97 @@ module Mongory
       self.and('$not' => condition)
     end
 
-    # Sorts results by given keys ascendingly.
+    # Adds one or more conditions combined with `$and`.
     #
-    # @param keys [Array<Symbol, String>]
+    # @param conditions [Array<Hash>]
     # @return [QueryBuilder]
-    def asc(*keys)
-      order_by_fields(*keys, direction: :asc)
+    def and(*conditions)
+      dup_instance_exec do
+        add_conditions('$and', conditions)
+      end
     end
 
-    # Sorts results by given keys descendingly.
+    # Adds one or more conditions combined with `$or`.
     #
-    # @param keys [Array<Symbol, String>]
+    # @param conditions [Array<Hash>]
     # @return [QueryBuilder]
-    def desc(*keys)
-      order_by_fields(*keys, direction: :desc)
+    def or(*conditions)
+      dup_instance_exec do
+        add_conditions('$or', conditions)
+      end
     end
 
-    # Limits the number of records returned.
+    # @deprecated Will be removed in v2.0.0. Sort externally instead.
+    # Sorts the records by the given keys in ascending order.
+    #
+    # @param sort_keys [Array<Symbol, String>]
+    # @return [QueryBuilder]
+    def asc(*sort_keys)
+      warn '[Mongory] `Mongory::QueryBuilder#asc` is deprecated and will be removed in v2.0.0.' \
+           'Please sort outside Mongory.'
+
+      dup_instance_exec do
+        @records = sort_by_keys(sort_keys) do |a, b|
+          a <=> b
+        end
+      end
+    end
+
+    # @deprecated Will be removed in v2.0.0. Sort externally instead.
+    # Sorts the records by the given keys in descending order.
+    #
+    # @param sort_keys [Array<Symbol, String>]
+    # @return [QueryBuilder]
+    def desc(*sort_keys)
+      warn '[Mongory] `Mongory::QueryBuilder#desc` is deprecated and will be removed in v2.0.0.' \
+           'Please sort outside Mongory.'
+
+      dup_instance_exec do
+        @records = sort_by_keys(sort_keys) do |a, b|
+          b <=> a
+        end
+      end
+    end
+
+    # Limits the number of records returned by the query.
     #
     # @param count [Integer]
     # @return [QueryBuilder]
     def limit(count)
       dup_instance_exec do
-        @limit = count
+        @records = take(count)
       end
     end
 
-    # Extracts specific fields from each record.
+    # Extracts selected fields from matching records.
     #
     # @param field [Symbol, String]
     # @param fields [Array<Symbol, String>]
     # @return [Array<Object>, Array<Array<Object>>]
     def pluck(field, *fields)
       if fields.empty?
-        map { |record| record[field.to_s] }
+        map { |record| record[field] }
       else
         fields.unshift(field)
-        map { |record| fields.map { |key| record[key.to_s] } }
+        map { |record| fields.map { |key| record[key] } }
       end
     end
+
+    # Returns the raw parsed condition for this query.
+    #
+    # @return [Hash] the raw compiled condition
+    def condition
+      @matcher.condition
+    end
+
+    alias_method :selector, :condition
 
     private
 
-    # Records sorting helper with direction.
+    # @private
+    # Duplicates the query and executes the block in context.
     #
-    # @param keys [Array<String, Symbol>]
-    # @param direction [Symbol] :asc or :desc
-    # @return [void]
-    def order_by_fields(*keys, direction:)
-      dup_instance_exec do
-        @sort_keys = keys
-        @sort_direction = direction
-      end
-    end
-
-    # Duplicates the current instance and runs a block inside it.
-    #
-    # @yield a block executed in the context of the cloned object
+    # @yieldparam dup [QueryBuilder]
     # @return [QueryBuilder]
     def dup_instance_exec(&block)
       dup.tap do |obj|
@@ -140,31 +155,39 @@ module Mongory
       end
     end
 
-    # Performs deep dup of internal state for immutable chaining.
+    # @private
+    # Builds the internal matcher tree from a condition hash.
+    # Used to eagerly parse conditions to improve inspect/debug visibility.
     #
-    # @return [QueryBuilder]
-    def dup
-      super.tap do |obj|
-        obj.instance_exec do
-          @condition = @condition.dup
-        end
-      end
+    # @param condition [Hash]
+    # @return [void]
+    def set_matcher(condition = {})
+      @matcher = QueryMatcher.new(condition)
     end
 
-    # Executes the actual query logic by evaluating the matcher.
+    # @private
+    # Merges additional conditions into the matcher.
     #
-    # @return [Array<Object>] filtered results
-    def result
-      matcher = Mongory::QueryMatcher.build(@condition)
-      res = @records.select { |r| matcher.match?(r) }
+    # @param key [String, Symbol]
+    # @param conditions [Array<Hash>]
+    def add_conditions(key, conditions)
+      condition_dup = @matcher.condition.dup
+      condition_dup[key] ||= []
+      condition_dup[key] += conditions
+      set_matcher(condition_dup)
+    end
 
-      if @sort_keys
-        res.sort_by! { |record| @sort_keys.map { |key| record[key.to_s] } }
-        res.reverse! if @sort_direction == :desc
+    # @private
+    # Sorts a list of records by one or more keys.
+    #
+    # @param sort_keys [Array]
+    # @yield [a, b] comparison block
+    # @return [Array]
+    def sort_by_keys(sort_keys)
+      sort do |a, b|
+        yield sort_keys.map { |key| a[key] },
+              sort_keys.map { |key| b[key] }
       end
-
-      res = res.take(@limit) if @limit
-      res
     end
   end
 end

--- a/lib/mongory/query_builder.rb
+++ b/lib/mongory/query_builder.rb
@@ -72,9 +72,23 @@ module Mongory
     # @param conditions [Array<Hash>]
     # @return [QueryBuilder]
     def or(*conditions)
+      operator = '$or'
       dup_instance_exec do
-        add_conditions('$or', conditions)
+        if @matcher.condition.each_key.all? { |k| k == operator }
+          add_conditions(operator, conditions)
+        else
+          set_matcher(operator => [@matcher.condition.dup, *conditions])
+        end
       end
+    end
+
+    # Adds a `$or` query combined inside an `$and` block.
+    # This is a semantic alias for `.and('$or' => [...])`
+    #
+    # @param conditions [Array<Hash>]
+    # @return [QueryBuilder]
+    def any_of(*conditions)
+      self.and('$or' => conditions)
     end
 
     # @deprecated Will be removed in v2.0.0. Sort externally instead.

--- a/lib/mongory/rails.rb
+++ b/lib/mongory/rails.rb
@@ -7,7 +7,9 @@ module Mongory
   # @see Utils::RailsPatch
   class Railtie < Rails::Railtie
     initializer 'mongory.patch_utils' do
-      Mongory::Utils.prepend(Mongory::Utils::RailsPatch)
+      [Mongory::Utils, *Mongory::Utils.included_classes].each do |klass|
+        klass.prepend(Mongory::Utils::RailsPatch)
+      end
     end
   end
 end

--- a/lib/mongory/utils.rb
+++ b/lib/mongory/utils.rb
@@ -11,11 +11,20 @@ module Mongory
   # and class-level instance method caching.
   module Utils
     # When included, also extends the including class with ClassMethods.
+    # And record which class include this module.
     #
     # @param base [Class, Module]
     def self.included(base)
       base.extend(ClassMethods)
       super
+      included_classes << base
+    end
+
+    # Where to record classes that include Utils.
+    #
+    # @return [Array]
+    def self.included_classes
+      @included_classes ||= []
     end
 
     # Checks if an object is "present".

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '1.6.4'
+  VERSION = '1.7.0'
 end

--- a/mongory.gemspec
+++ b/mongory.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (File.expand_path(f) == __FILE__) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w(bin/ test/ spec/ features/ .git .github appveyor Gemfile))
     end
   end
   spec.bindir = 'exe'

--- a/spec/query_builder_spec.rb
+++ b/spec/query_builder_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe Mongory::QueryBuilder do
 
     let(:records) do
       [
-        { 'name' => 'Alice', 'age' => 30, 'tags' => ['ruby'] },
-        { 'name' => 'Bob', 'age' => 25, 'tags' => ['qa'] },
-        { 'name' => 'Carol', 'age' => 35, 'tags' => ['ruby'] },
-        { 'name' => 'Dave', 'age' => 20, 'tags' => ['js'] },
-        { 'name' => 'Eve', 'age' => 32, 'tags' => ['qa'] }
+        { name: 'Alice', age: 30, tags: ['ruby'] },
+        { name: 'Bob', age: 25, tags: ['qa'] },
+        { name: 'Carol', age: 35, tags: ['ruby'] },
+        { name: 'Dave', age: 20, tags: ['js'] },
+        { name: 'Eve', age: 32, tags: ['qa'] }
       ]
     end
 
@@ -34,15 +34,15 @@ RSpec.describe Mongory::QueryBuilder do
     subject { described_class.new(records).where(:age.gt => 28) }
     let(:records) do
       [
-        { 'name' => 'Alice', 'age' => 30 },
-        { 'name' => 'Bob', 'age' => 25 },
-        { 'name' => 'Carol', 'age' => 35 }
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: 25 },
+        { name: 'Carol', age: 35 }
       ]
     end
 
     it 'is enumerable' do
       names = []
-      subject.each { |r| names << r['name'] }
+      subject.each { |r| names << r[:name] }
       expect(names).to contain_exactly('Alice', 'Carol')
       expect(names).not_to be_include('Bob')
     end
@@ -50,7 +50,7 @@ RSpec.describe Mongory::QueryBuilder do
     it 'returns an enumerator when no block given' do
       enumerator = subject.each
       expect(enumerator).to be_a(Enumerator)
-      names = enumerator.map { |x| x['name'] }
+      names = enumerator.map { |x| x[:name] }
       expect(names).to contain_exactly('Alice', 'Carol')
       expect(names).not_to contain_exactly('Bob')
     end
@@ -276,10 +276,10 @@ RSpec.describe Mongory::QueryBuilder do
     subject { described_class.new(records).asc(order_key) }
     let(:records) do
       [
-        { 'name' => 'Alice', 'age' => 30 },
-        { 'name' => 'Bob', 'age' => 25 },
-        { 'name' => 'Carol', 'age' => 35 },
-        { 'name' => 'Dave', 'age' => 20 }
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: 25 },
+        { name: 'Carol', age: 35 },
+        { name: 'Dave', age: 20 }
       ]
     end
 
@@ -287,7 +287,7 @@ RSpec.describe Mongory::QueryBuilder do
       let(:order_key) { :age }
 
       it 'sorts records from youngest to oldest' do
-        expect(subject.pluck('name')).to eq(['Dave', 'Bob', 'Alice', 'Carol'])
+        expect(subject.pluck(:name)).to eq(['Dave', 'Bob', 'Alice', 'Carol'])
       end
     end
 
@@ -295,7 +295,7 @@ RSpec.describe Mongory::QueryBuilder do
       let(:order_key) { :name }
 
       it 'sorts records alphabetically' do
-        expect(subject.pluck('name')).to eq(['Alice', 'Bob', 'Carol', 'Dave'])
+        expect(subject.pluck(:name)).to eq(['Alice', 'Bob', 'Carol', 'Dave'])
       end
     end
   end
@@ -304,10 +304,10 @@ RSpec.describe Mongory::QueryBuilder do
     subject { described_class.new(records).desc(order_key) }
     let(:records) do
       [
-        { 'name' => 'Alice', 'age' => 30 },
-        { 'name' => 'Bob', 'age' => 25 },
-        { 'name' => 'Carol', 'age' => 35 },
-        { 'name' => 'Dave', 'age' => 20 }
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: 25 },
+        { name: 'Carol', age: 35 },
+        { name: 'Dave', age: 20 }
       ]
     end
 
@@ -315,7 +315,7 @@ RSpec.describe Mongory::QueryBuilder do
       let(:order_key) { :age }
 
       it 'sorts records from oldest to youngest' do
-        expect(subject.pluck('name')).to eq(['Carol', 'Alice', 'Bob', 'Dave'])
+        expect(subject.pluck(:name)).to eq(['Carol', 'Alice', 'Bob', 'Dave'])
       end
     end
 
@@ -323,7 +323,7 @@ RSpec.describe Mongory::QueryBuilder do
       let(:order_key) { :name }
 
       it 'sorts records in reverse alphabetical order' do
-        expect(subject.pluck('name')).to eq(['Dave', 'Carol', 'Bob', 'Alice'])
+        expect(subject.pluck(:name)).to eq(['Dave', 'Carol', 'Bob', 'Alice'])
       end
     end
   end
@@ -368,10 +368,10 @@ RSpec.describe Mongory::QueryBuilder do
     subject { described_class.new(records).pluck(*fields) }
     let(:records) do
       [
-        { 'name' => 'Alice', 'age' => 30 },
-        { 'name' => 'Bob', 'age' => 25 },
-        { 'name' => 'Carol', 'age' => 35 },
-        { 'name' => 'Dave', 'age' => 20 }
+        { name: 'Alice', age: 30 },
+        { name: 'Bob', age: 25 },
+        { name: 'Carol', age: 35 },
+        { name: 'Dave', age: 20 }
       ]
     end
 
@@ -397,9 +397,9 @@ RSpec.describe Mongory::QueryBuilder do
     context 'when field is missing in some records' do
       let(:records) do
         [
-          { 'name' => 'Alice', 'age' => 30 },
-          { 'name' => 'Bob' },
-          { 'name' => 'Carol', 'age' => 35 }
+          { name: 'Alice', age: 30 },
+          { name: 'Bob' },
+          { name: 'Carol', age: 35 }
         ]
       end
 

--- a/spec/query_builder_spec.rb
+++ b/spec/query_builder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Mongory::QueryBuilder do
         .new(records)
         .where(:tags.in => ['ruby', 'qa'])
         .and(:age.gte => 25)
-        .or({ name: /e/ }, { :tags.present => true })
+        .any_of({ name: /e/ }, { :tags.present => true })
         .asc(:age)
         .limit(3)
         .pluck(:name)

--- a/spec/query_builder_spec.rb
+++ b/spec/query_builder_spec.rb
@@ -44,12 +44,15 @@ RSpec.describe Mongory::QueryBuilder do
       names = []
       subject.each { |r| names << r['name'] }
       expect(names).to contain_exactly('Alice', 'Carol')
+      expect(names).not_to be_include('Bob')
     end
 
     it 'returns an enumerator when no block given' do
       enumerator = subject.each
       expect(enumerator).to be_a(Enumerator)
-      expect(enumerator.map { |r| r['name'] }).to contain_exactly('Alice', 'Carol')
+      names = enumerator.map { |x| x['name'] }
+      expect(names).to contain_exactly('Alice', 'Carol')
+      expect(names).not_to contain_exactly('Bob')
     end
   end
 
@@ -68,12 +71,14 @@ RSpec.describe Mongory::QueryBuilder do
       let(:condition) { { :age.gt => 28 } }
 
       it { is_expected.to contain_exactly(include('name' => 'Alice'), include('name' => 'Carol')) }
+      it { is_expected.not_to contain_exactly(include('name' => 'Bob')) }
     end
 
     context 'when filtering by equality' do
       let(:condition) { { name: 'Bob' } }
 
       it { is_expected.to contain_exactly(include('name' => 'Bob')) }
+      it { is_expected.not_to contain_exactly(include('name' => 'Alice'), include('name' => 'Carol')) }
     end
 
     context 'when filtering by in operator' do
@@ -220,6 +225,7 @@ RSpec.describe Mongory::QueryBuilder do
           include('name' => 'Carol'),
           include('name' => 'Dave')
         )
+        is_expected.not_to contain_exactly(include('name' => 'Alice'))
       end
     end
 

--- a/spec/query_matcher_spec.rb
+++ b/spec/query_matcher_spec.rb
@@ -170,11 +170,11 @@ RSpec.describe Mongory::QueryMatcher, type: :model do
         end
 
         context 'when compare with array' do
-          let(:tags) { %w[tag1 tag2] }
+          let(:tags) { %w(tag1 tag2) }
 
-          it { is_expected.to be_match(tags: %w[tag1 tag2]) }
+          it { is_expected.to be_match(tags: %w(tag1 tag2)) }
           it { is_expected.not_to be_match(tags: ['tag1']) }
-          it { is_expected.not_to be_match(tags: %w[tag2 tag1]) }
+          it { is_expected.not_to be_match(tags: %w(tag2 tag1)) }
           it { is_expected.not_to be_match(tags: 'tag1') }
         end
 
@@ -182,8 +182,8 @@ RSpec.describe Mongory::QueryMatcher, type: :model do
           let(:tags) { 'tag1' }
 
           it { is_expected.to be_match(tags: ['tag1']) }
-          it { is_expected.to be_match(tags: %w[tag1 tag2]) }
-          it { is_expected.to be_match(tags: %w[tag2 tag1]) }
+          it { is_expected.to be_match(tags: %w(tag1 tag2)) }
+          it { is_expected.to be_match(tags: %w(tag2 tag1)) }
           it { is_expected.not_to be_match(tags: ['tag2']) }
         end
 
@@ -698,14 +698,14 @@ RSpec.describe Mongory::QueryMatcher, type: :model do
     end
 
     context 'use operator $in' do
-      let(:collection) { %w[foo bar] }
+      let(:collection) { %w(foo bar) }
 
       shared_examples_for 'in behaviors' do
         it { is_expected.to be_match(name: 'foo') }
         it { is_expected.to be_match(name: 'bar') }
         it { is_expected.to be_match(name: ['foo']) }
         it { is_expected.to be_match(name: ['bar']) }
-        it { is_expected.to be_match(name: %w[foo bar]) }
+        it { is_expected.to be_match(name: %w(foo bar)) }
         it { is_expected.not_to be_match(name: 'lala') }
         it { is_expected.not_to be_match(name: nil) }
         it { is_expected.not_to be_match(anything) }
@@ -743,7 +743,7 @@ RSpec.describe Mongory::QueryMatcher, type: :model do
     end
 
     context 'use operator $nin' do
-      let(:collection) { %w[foo bar] }
+      let(:collection) { %w(foo bar) }
 
       shared_examples_for 'nin behaviors' do
         it { is_expected.to be_match(name: 'ann') }


### PR DESCRIPTION
🎉 Mongory v1.7.0 – Lazy Filters, Tree Explain, and Better OR Semantics

This release introduces major internal refinements to query execution, matcher introspection, and `$or` logic.

### ✨ What's New

- **Matcher Tree Explain**
  - Use `QueryBuilder#explain` to visualize the matcher tree structure via pretty-printed output.
  - All matchers now support `#render_tree` and `#tree_title` for structured introspection.

- **Filter Evaluation Overhaul**
  - `QueryBuilder` now builds matcher trees immediately via `set_matcher`.
  - Removed `.result` and the old condition hash model.
  - `.each` now filters through the matcher directly for improved traceability and performance.

- **Improved `$or` Operator Semantics**
  - `.or(...)` intelligently merges into existing `$or`-only trees.
  - Added `.any_of(...)` as a semantic alternative to `.and('$or' => [...])`.

### ⚠️ Deprecations

- `.asc` and `.desc` are now deprecated and emit warnings.
  Please sort externally and prepare for removal in v2.0.0.

---

This release lays the groundwork for introspectable and explainable matcher queries.
Ideal for debugging and advanced query inspection use cases.