### PR TITLE
Release/2.0.0 beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [2.0.0-beta.2] - 2025-04-16
+
+### Changed
+- Refactored all converter classes (`DataConverter`, `KeyConverter`, `ValueConverter`, `ConditionConverter`) into singleton classes inheriting from `AbstractConverter`
+- Introduced `default_registrations` hook method to encapsulate converter setup logic internally
+- Migrated fallback logic into `initialize`, removed reliance on `instance_eval`
+- Renamed `converter_builder.rb` to `abstract_converter.rb`
+- Refactored `Debugger` into a singleton class with `include Singleton`
+- Moved `Debugger`'s setup logic into `initialize`
+- All references to converters and debugger updated to use `.instance`
+
+### Breaking Changes
+- Removed support for direct `.convert(...)` calls on converter constants (e.g., `KeyConverter.convert`); use `.instance.convert(...)` instead
+- Removed `.configure` DSL on `ConditionConverter`; use `default_registrations` override instead
+- Replaced `Debugger.method` access with `Debugger.instance.method`
+
 ## [2.0.0-beta.1] - Unreleased - 2025-4-16
 
 ### ⚠️ Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (2.0.0.pre.beta.1)
+    mongory (2.0.0.pre.beta.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -2,6 +2,7 @@
 
 require 'time'
 require 'date'
+require 'singleton'
 require_relative 'mongory/version'
 require_relative 'mongory/utils'
 require_relative 'mongory/matchers'
@@ -56,14 +57,14 @@ module Mongory
   #
   # @return [Converters::DataConverter]
   def self.data_converter
-    Converters::DataConverter
+    Converters::DataConverter.instance
   end
 
   # Returns the condition converter instance.
   #
   # @return [Converters::ConditionConverter]
   def self.condition_converter
-    Converters::ConditionConverter
+    Converters::ConditionConverter.instance
   end
 
   # Returns the debugger instance.

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -71,7 +71,7 @@ module Mongory
   #
   # @return [Utils::Debugger]
   def self.debugger
-    Utils::Debugger
+    Utils::Debugger.instance
   end
 
   # Builds a new query over the given record set.

--- a/lib/mongory/converters.rb
+++ b/lib/mongory/converters.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'converters/converter_builder'
+require_relative 'converters/abstract_converter'
 require_relative 'converters/condition_converter'
 require_relative 'converters/data_converter'
 require_relative 'converters/key_converter'

--- a/lib/mongory/converters/abstract_converter.rb
+++ b/lib/mongory/converters/abstract_converter.rb
@@ -2,18 +2,18 @@
 
 module Mongory
   module Converters
-    # ConverterBuilder provides a flexible DSL-style mechanism
+    # AbstractConverter provides a flexible DSL-style mechanism
     # for dynamically converting objects based on their class.
     #
     # It allows you to register conversion rules for specific classes,
     # with optional fallback behavior.
     #
     # @example Basic usage
-    #   converter = ConverterBuilder.new do
+    #   converter = AbstractConverter.new do
     #     register(String) { |v| v.upcase }
     #   end
     #   converter.convert("hello") #=> "HELLO"
-    class ConverterBuilder < Utils::SingletonBuilder
+    class AbstractConverter < Utils::SingletonBuilder
       # @private
       Registry = Struct.new(:klass, :exec)
 

--- a/lib/mongory/converters/abstract_converter.rb
+++ b/lib/mongory/converters/abstract_converter.rb
@@ -9,11 +9,13 @@ module Mongory
     # with optional fallback behavior.
     #
     # @example Basic usage
-    #   converter = AbstractConverter.new do
-    #     register(String) { |v| v.upcase }
-    #   end
+    #   converter = AbstractConverter.instance
+    #   converter.register(String) { |v| v.upcase }
     #   converter.convert("hello") #=> "HELLO"
+    #
     class AbstractConverter < Utils::SingletonBuilder
+      include Singleton
+
       # @private
       Registry = Struct.new(:klass, :exec)
 
@@ -21,13 +23,11 @@ module Mongory
       NOTHING = Utils::SingletonBuilder.new('NOTHING')
 
       # Initializes the builder with a label and optional configuration block.
-      #
-      # @param label [String] a name for the converter
-      # @yield [block] optional configuration block
-      def initialize(label, &block)
+      def initialize
+        super(self.class.to_s)
         @registries = []
         @fallback = Proc.new { |*| self }
-        super
+        default_registrations
       end
 
       # Applies the registered conversion to the given target object.
@@ -95,6 +95,8 @@ module Mongory
           raise 'Support Symbol and block only.'
         end
       end
+
+      def default_registrations; end
     end
   end
 end

--- a/lib/mongory/converters/condition_converter.rb
+++ b/lib/mongory/converters/condition_converter.rb
@@ -51,14 +51,14 @@ module Mongory
 
       # Returns the key converter used to transform condition keys.
       #
-      # @return [ConverterBuilder]
+      # @return [AbstractConverter]
       def key_converter
         KeyConverter
       end
 
       # Returns the value converter used to transform condition values.
       #
-      # @return [ConverterBuilder]
+      # @return [AbstractConverter]
       def value_converter
         ValueConverter
       end

--- a/lib/mongory/converters/data_converter.rb
+++ b/lib/mongory/converters/data_converter.rb
@@ -10,7 +10,7 @@ module Mongory
     # - Strings and Integers are passed through as-is
     #
     # This converter is typically applied to raw query values.
-    DataConverter = ConverterBuilder.new('Mongory::Converters::DataConverter') do
+    DataConverter = AbstractConverter.new('Mongory::Converters::DataConverter') do
       [Symbol, Date].each do |klass|
         register(klass, :to_s)
       end

--- a/lib/mongory/converters/data_converter.rb
+++ b/lib/mongory/converters/data_converter.rb
@@ -2,25 +2,24 @@
 
 module Mongory
   module Converters
-    # Provides a default converter that normalizes input data types
-    # for internal query processing.
-    #
+    # DataConverter handles automatic transformation of raw query values.
+    # This class inherits from AbstractConverter and provides predefined conversions for
+    # common primitive types like Symbol, Date, Time, etc.
     # - Symbols and Dates are converted to string
     # - Time and DateTime objects are ISO8601-encoded
     # - Strings and Integers are passed through as-is
     #
-    # This converter is typically applied to raw query values.
-    DataConverter = AbstractConverter.new('Mongory::Converters::DataConverter') do
-      [Symbol, Date].each do |klass|
-        register(klass, :to_s)
-      end
-
-      [Time, DateTime].each do |klass|
-        register(klass, :iso8601)
-      end
-
-      [String, Integer].each do |klass|
-        register(klass) { self }
+    # @example Convert a symbol
+    #   DataConverter.instance.convert(:status) #=> "status"
+    #
+    class DataConverter < AbstractConverter
+      def default_registrations
+        register(Symbol, :to_s)
+        register(Date, :to_s)
+        register(Time, :iso8601)
+        register(DateTime, :iso8601)
+        register(String, :itself)
+        register(Integer, :itself)
       end
     end
   end

--- a/lib/mongory/converters/key_converter.rb
+++ b/lib/mongory/converters/key_converter.rb
@@ -2,36 +2,54 @@
 
 module Mongory
   module Converters
-    # Converts dotted keys like `"foo.bar"` or `:"foo.bar"` into nested hashes.
+    # KeyConverter handles transformation of field keys in query conditions.
+    # It normalizes symbol keys into string paths, splits dotted keys,
+    # and delegates to the appropriate converter logic.
     #
+    # This class inherits from AbstractConverter and registers rules for
+    # strings, symbols, and includes a fallback handler.
     # Used by ConditionConverter to build query structures from flat input.
     #
     # - `"a.b.c" => v` becomes `{ "a" => { "b" => { "c" => v } } }`
     # - Symbols are stringified and delegated to String logic
     # - QueryOperator dispatches to internal DSL hook
-    KeyConverter = AbstractConverter.new('Mongory::Converters::KeyConverter') do |c|
-      # fallback if key type is unknown — returns { self => value }
-      @fallback = ->(x) { { self => x } }
+    #
+    # @example Convert a dotted string key
+    #   KeyConverter.instance.convert("user.name") #=> { "user" => { "name" => value } }
+    #
+    class KeyConverter < AbstractConverter
+      def initialize
+        super
+        # fallback if key type is unknown — returns { self => value }
+        @fallback = ->(x) { { self => x } }
+      end
+
+      def default_registrations
+        convert_string_key = method(:convert_string_key)
+        register(String) do |value|
+          convert_string_key.call(self, value)
+        end
+
+        # - `:"a.b.c" => v` becomes `{ "a" => { "b" => { "c" => v } } }`
+        register(Symbol) do |other|
+          convert_string_key.call(to_s, other)
+        end
+
+        # - `:"a.b.c".present => true` becomes `{ "a" => { "b" => { "c" => { "$present" => true } } } }`
+        register(QueryOperator, :__expr_part__)
+      end
 
       # - `"a.b.c" => v` becomes `{ "a" => { "b" => { "c" => v } } }`
-      register(String) do |other|
+      def convert_string_key(key, value)
         ret = {}
-        *keys, last_key = split('.')
-        last_hash = keys.reduce(ret) do |res, key|
-          next_res = res[key] = {}
+        *sub_keys, last_key = key.split('.')
+        last_hash = sub_keys.reduce(ret) do |res, sub_key|
+          next_res = res[sub_key] = {}
           next_res
         end
-        last_hash[last_key] = other
+        last_hash[last_key] = value
         ret
       end
-
-      # - `:"a.b.c" => v` becomes `{ "a" => { "b" => { "c" => v } } }`
-      register(Symbol) do |other|
-        c.convert(to_s, other)
-      end
-
-      # - `:"a.b.c".present => true` becomes `{ "a" => { "b" => { "c" => { "$present" => true } } } }`
-      register(QueryOperator, :__expr_part__)
     end
   end
 end

--- a/lib/mongory/converters/key_converter.rb
+++ b/lib/mongory/converters/key_converter.rb
@@ -9,7 +9,7 @@ module Mongory
     # - `"a.b.c" => v` becomes `{ "a" => { "b" => { "c" => v } } }`
     # - Symbols are stringified and delegated to String logic
     # - QueryOperator dispatches to internal DSL hook
-    KeyConverter = ConverterBuilder.new('Mongory::Converters::KeyConverter') do |c|
+    KeyConverter = AbstractConverter.new('Mongory::Converters::KeyConverter') do |c|
       # fallback if key type is unknown — returns { self => value }
       @fallback = ->(x) { { self => x } }
 

--- a/lib/mongory/converters/value_converter.rb
+++ b/lib/mongory/converters/value_converter.rb
@@ -11,7 +11,7 @@ module Mongory
     # - Regex becomes a Mongo-style `$regex` hash
     # - Strings and Integers are passed through
     # - Everything else falls back to DataConverter
-    ValueConverter = ConverterBuilder.new('Mongory::Converters::ValueConverter') do |c|
+    ValueConverter = AbstractConverter.new('Mongory::Converters::ValueConverter') do |c|
       # fallback for unrecognized types
       @fallback = -> { DataConverter.convert(self) }
 

--- a/lib/mongory/matchers/abstract_matcher.rb
+++ b/lib/mongory/matchers/abstract_matcher.rb
@@ -71,7 +71,7 @@ module Mongory
       # @return [Boolean] whether the match succeeded
       def debug_match(record)
         result = nil
-        Debugger.with_indent do
+        Debugger.instance.with_indent do
           result = match(record)
           debug_display(record, result)
         end

--- a/lib/mongory/query_operator.rb
+++ b/lib/mongory/query_operator.rb
@@ -41,7 +41,7 @@ module Mongory
     # @param other [Object] the value to match against
     # @return [Hash] converted query condition
     def __expr_part__(other, *)
-      Converters::KeyConverter.convert(@name, @operator => other)
+      Converters::KeyConverter.instance.convert(@name, @operator => other)
     end
   end
 end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '2.0.0-beta.1'
+  VERSION = '2.0.0-beta.2'
 end

--- a/spec/data_converter_spec.rb
+++ b/spec/data_converter_spec.rb
@@ -5,19 +5,6 @@ require 'spec_helper'
 RSpec.describe 'Mongory.data_converter' do
   subject { Mongory.data_converter }
 
-  before(:all) do
-    enforce_reset_converter(
-      :data_converter,
-      converter_deep_dup(Mongory.data_converter)
-    )
-  end
-
-  around(:each) do |example|
-    converter = converter_deep_dup(Mongory.data_converter)
-    example.run
-    enforce_reset_converter(:data_converter, converter)
-  end
-
   describe 'interface safety' do
     it 'cannot be instantiated with .new' do
       expect { described_class.new }.to raise_error(NoMethodError)

--- a/spec/query_matcher_spec.rb
+++ b/spec/query_matcher_spec.rb
@@ -5,13 +5,13 @@ require 'spec_helper'
 DummyModel = Struct.new(:as_json)
 FakeBsonId = Struct.new(:to_s)
 
-Mongory.data_converter.configure do |c|
-  c.register(DummyModel) do
-    c.convert(as_json)
-  end
+converter = Mongory.data_converter
 
-  c.register(FakeBsonId, :to_s)
+converter.register(DummyModel) do
+  converter.convert(as_json)
 end
+
+converter.register(FakeBsonId, :to_s)
 
 RSpec.describe Mongory::QueryMatcher, type: :model do
   subject { described_class.new(condition) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,19 +13,6 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  def converter_deep_dup(converter)
-    converter = converter.dup
-    converter.instance_exec do
-      @registries = @registries.dup
-      @fallback = @fallback.dup
-    end
-    converter
-  end
-
-  def enforce_reset_converter(method, converter)
-    Mongory.define_singleton_method(method) { converter }
-  end
-
   Mongory.enable_symbol_snippets!
   Mongory.register(Array)
 end


### PR DESCRIPTION
## [2.0.0-beta.2] - 2025-04-16

### Changed
- Refactored all converter classes (`DataConverter`, `KeyConverter`, `ValueConverter`, `ConditionConverter`) into singleton classes inheriting from `AbstractConverter`
- Introduced `default_registrations` hook method to encapsulate converter setup logic internally
- Migrated fallback logic into `initialize`, removed reliance on `instance_eval`
- Renamed `converter_builder.rb` to `abstract_converter.rb`
- Refactored `Debugger` into a singleton class with `include Singleton`
- Moved `Debugger`'s setup logic into `initialize`
- All references to converters and debugger updated to use `.instance`

### Breaking Changes
- Removed support for direct `.convert(...)` calls on converter constants (e.g., `KeyConverter.convert`); use `.instance.convert(...)` instead
- Removed `.configure` DSL on `ConditionConverter`; use `default_registrations` override instead
- Replaced `Debugger.method` access with `Debugger.instance.method`